### PR TITLE
Check if CMake and C++ compiler are available when building jupedsim

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
+min_cpp_standard = 20
+min_cmake_version = "3.19"
+
 # Read version number from CMakeLists.txt
 with open("CMakeLists.txt", "r", encoding="utf-8") as cmakelist:
     cmake_input = cmakelist.read()
@@ -36,7 +39,18 @@ PLAT_TO_CMAKE = {
 
 def check_cmake():
     try:
-        subprocess.run(["cmake", "--version"], check=True)
+        result = subprocess.run(
+            ["cmake", "--version"], check=True, capture_output=True, text=True
+        )
+        # Check CMake version
+        found_cmake_version = re.search(
+            r"(\d+).(\d+).(\d+)", str(result.stdout)
+        )
+        for min_version, found_version in zip(
+            min_cmake_version.split("."), found_cmake_version.groups()
+        ):
+            if found_version < min_version:
+                return False
     except:
         return False
     return True
@@ -56,10 +70,11 @@ def check_cpp_compiler():
             cp_file.write(simple_main)
 
         simple_cmake = textwrap.dedent(
-            """
+            f"""
             cmake_minimum_required(VERSION 3.19)
             project(SimpleTest)
-
+            set(CMAKE_CXX_STANDARD {min_cpp_standard})
+            set(CMAKE_CXX_STANDARD_REQUIRED ON)
             add_executable(simple_test main.cpp)
             """
         )
@@ -93,14 +108,16 @@ class CMakeBuild(build_ext):
     def build_extension(self, ext: CMakeExtension) -> None:
         if not check_cmake():
             raise ModuleNotFoundError(
-                "No CMake installation found on the system, "
-                "please install CMake to install JuPedSim."
+                f"No CMake or no CMake >= {min_cmake_version} installation "
+                f"found on the system, please install "
+                f"CMake >= {min_cmake_version} to install JuPedSim."
             )
 
         if not check_cpp_compiler():
             raise ModuleNotFoundError(
                 "Could not compile a simple C++ program, "
-                "please install a C++ compiler to install JuPedSim."
+                f"please install a C++ compiler with C++{min_cpp_standard} "
+                f"support to install JuPedSim."
             )
 
         # Must be in this form due to bug in .resolve() only fixed in Python 3.10+


### PR DESCRIPTION
When installing JuPedSim via PyPI or locally, it will be checked whether CMake and a C++ Compiler are available, if not some error messages will be displayed to the users.

Closes #1157 