### PR TITLE
Expose build meta information to user

### DIFF
--- a/python_modules/jupedsim/jupedsim/__init__.py
+++ b/python_modules/jupedsim/jupedsim/__init__.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 Forschungszentrum Jülich GmbH
 # SPDX-License-Identifier: LGPL-3.0-or-later
+
 from jupedsim.distributions import (
     AgentNumberError,
     IncorrectParameterError,
@@ -50,6 +51,12 @@ from jupedsim.util import (
     geometry_from_wkt,
 )
 
+__version__ = get_build_info().library_version
+__commit__ = get_build_info().git_commit_hash
+__compiler__ = (
+    f"{get_build_info().compiler} ({get_build_info().compiler_version})"
+)
+
 __all__ = [
     "AgentNumberError",
     "IncorrectParameterError",
@@ -93,4 +100,8 @@ __all__ = [
     "geometry_from_shapely",
     "geometry_from_coordinates",
     "GeometryError",
+    "build_jps_geometry",
+    "__version__",
+    "__commit__",
+    "__compiler__",
 ]

--- a/python_modules/jupedsim/jupedsim/native/library.py
+++ b/python_modules/jupedsim/jupedsim/native/library.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     from .. import py_jupedsim as py_jps
 
+from textwrap import dedent
+
 
 # TODO(kkratz): add typehints for function params
 def set_debug_callback(fn) -> None:
@@ -84,6 +86,15 @@ class BuildInfo:
     @property
     def library_version(self) -> str:
         return self.__obj.library_version
+
+    def __repr__(self):
+        return dedent(
+            f"""\
+            JuPedSim {self.library_version}:
+            --------------------------------
+            Commit: {self.git_commit_hash} from {self.git_branch} on {self.git_commit_date}
+            Compiler: {self.compiler} ({self.compiler_version})"""
+        )
 
 
 def get_build_info() -> BuildInfo:


### PR DESCRIPTION
- make library version, compiler version and commit hash directly accessible
- add to string method for BuildInfo with more detailed information
```bash
>>> import jupedsim
>>> jupedsim.__version__
'0.11.0'
>>> jupedsim.__commit__
'aa4a6d4f4'
>>> jupedsim.__compiler__
'GNU (13.2.1)'
>>> jupedsim.get_build_info()
JuPedSim 0.11.0:
--------------------------------
Commit: aa4a6d4f4 from native-wrapper on Thu Sep 7 13:14:01 2023
Compiler: GNU (13.2.1)
>>> 

```