### PR TITLE
fixing link in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,7 +46,7 @@ It is easiest to install directly with pip from
     pip install jupedsim
 
 
-For information how to build *JuPedSim* from source, visit our `GitHub repository <https://github.com/PedestrianDynamics/jupedsim/)>`_.
+For information how to build *JuPedSim* from source, visit our `GitHub repository <https://github.com/PedestrianDynamics/jupedsim/>`_.
 
 Main features
 =============


### PR DESCRIPTION
The link to the GitHub repo has an undesired `)` at the end