### PR TITLE
Add direct steering for agents

### DIFF
--- a/libjupedsim/include/jupedsim/jupedsim.h
+++ b/libjupedsim/include/jupedsim/jupedsim.h
@@ -792,8 +792,6 @@ JUPEDSIM_API void JPS_ExitProxy_Free(JPS_ExitProxy handle);
 
 typedef struct JPS_DirectSteeringProxy_t* JPS_DirectSteeringProxy;
 
-JUPEDSIM_API size_t JPS_DirectSteeringProxy_GetCountTargeting(JPS_DirectSteeringProxy handle);
-
 JUPEDSIM_API void JPS_DirectSteeringProxy_Free(JPS_DirectSteeringProxy handle);
 
 /**
@@ -830,14 +828,14 @@ JUPEDSIM_API JPS_StageId JPS_Agent_GetStageId(JPS_Agent handle);
 JUPEDSIM_API JPS_Point JPS_Agent_GetPosition(JPS_Agent handle);
 
 /**
- * Access the agents waypoint.
+ * Access the agents current target.
  * @param handle of the agent to access.
- * @return waypoint
+ * @return target of the agent
  */
-JUPEDSIM_API JPS_Point JPS_Agent_GetWayPoint(JPS_Agent handle);
+JUPEDSIM_API JPS_Point JPS_Agent_GetTarget(JPS_Agent handle);
 
 JUPEDSIM_API bool
-JPS_Agent_SetWayPoint(JPS_Agent handle, JPS_Point waypoint, JPS_ErrorMessage* errorMessage);
+JPS_Agent_SetTarget(JPS_Agent handle, JPS_Point target, JPS_ErrorMessage* errorMessage);
 
 /**
  * Access the agents orientation.
@@ -1114,7 +1112,15 @@ JUPEDSIM_API JPS_StageId JPS_Simulation_AddStageWaitingSet(
     JPS_ErrorMessage* errorMessage);
 
 /**
- * @todo
+ * Adds a new direct steering stage to the simulation.
+ *
+ * This allows a direct control of the target of an agent.
+ *
+ * Important: A direct steering stage can only be used if it is the only stage in a Journey.
+ *
+ * @param handle to the simulation to act on
+ * @param[out] errorMessage if not NULL: will be set to a JPS_ErrorMessage in case of an error.
+ * @return Id of the stage
  */
 JUPEDSIM_API JPS_StageId
 JPS_Simulation_AddStageDirectSteering(JPS_Simulation handle, JPS_ErrorMessage* errorMessage);

--- a/libjupedsim/include/jupedsim/jupedsim.h
+++ b/libjupedsim/include/jupedsim/jupedsim.h
@@ -737,7 +737,13 @@ JPS_CollisionFreeSpeedModelState_SetRadius(JPS_CollisionFreeSpeedModelState hand
 /**
  * Identifies the type of stage
  */
-enum JPS_StageType { JPS_NotifiableQueueType, JPS_WaitingSetType, JPS_WaypointType, JPS_ExitType };
+enum JPS_StageType {
+    JPS_NotifiableQueueType,
+    JPS_WaitingSetType,
+    JPS_WaypointType,
+    JPS_ExitType,
+    JPS_DirectSteeringType
+};
 
 /**
  * Opaque type of an NotifiableQueueProxy
@@ -784,6 +790,12 @@ JUPEDSIM_API size_t JPS_ExitProxy_GetCountTargeting(JPS_ExitProxy handle);
 
 JUPEDSIM_API void JPS_ExitProxy_Free(JPS_ExitProxy handle);
 
+typedef struct JPS_DirectSteeringProxy_t* JPS_DirectSteeringProxy;
+
+JUPEDSIM_API size_t JPS_DirectSteeringProxy_GetCountTargeting(JPS_DirectSteeringProxy handle);
+
+JUPEDSIM_API void JPS_DirectSteeringProxy_Free(JPS_DirectSteeringProxy handle);
+
 /**
  * Opaque type of an agent
  */
@@ -816,6 +828,16 @@ JUPEDSIM_API JPS_StageId JPS_Agent_GetStageId(JPS_Agent handle);
  * @return position
  */
 JUPEDSIM_API JPS_Point JPS_Agent_GetPosition(JPS_Agent handle);
+
+/**
+ * Access the agents waypoint.
+ * @param handle of the agent to access.
+ * @return waypoint
+ */
+JUPEDSIM_API JPS_Point JPS_Agent_GetWayPoint(JPS_Agent handle);
+
+JUPEDSIM_API bool
+JPS_Agent_SetWayPoint(JPS_Agent handle, JPS_Point waypoint, JPS_ErrorMessage* errorMessage);
 
 /**
  * Access the agents orientation.
@@ -1092,6 +1114,12 @@ JUPEDSIM_API JPS_StageId JPS_Simulation_AddStageWaitingSet(
     JPS_ErrorMessage* errorMessage);
 
 /**
+ * @todo
+ */
+JUPEDSIM_API JPS_StageId
+JPS_Simulation_AddStageDirectSteering(JPS_Simulation handle, JPS_ErrorMessage* errorMessage);
+
+/**
  * Adds a new agent to the simulation.
  * This can be called at any time, i.e. agents can be added at any iteration.
  * NOTE: Currently there is no checking done to ensure the agent can be placed at the desired
@@ -1260,6 +1288,11 @@ JUPEDSIM_API JPS_WaypointProxy JPS_Simulation_GetWaypointProxy(
     JPS_ErrorMessage* errorMessage);
 
 JUPEDSIM_API JPS_ExitProxy JPS_Simulation_GetExitProxy(
+    JPS_Simulation handle,
+    JPS_StageId stageId,
+    JPS_ErrorMessage* errorMessage);
+
+JUPEDSIM_API JPS_DirectSteeringProxy JPS_Simulation_GetDirectSteeringProxy(
     JPS_Simulation handle,
     JPS_StageId stageId,
     JPS_ErrorMessage* errorMessage);

--- a/libjupedsim/src/jupedsim.cpp
+++ b/libjupedsim/src/jupedsim.cpp
@@ -727,19 +727,19 @@ JPS_Point JPS_Agent_GetPosition(JPS_Agent handle)
     return intoJPS_Point(agent->pos);
 }
 
-JPS_Point JPS_Agent_GetWayPoint(JPS_Agent handle)
+JPS_Point JPS_Agent_GetTarget(JPS_Agent handle)
 {
     assert(handle);
     const auto agent = reinterpret_cast<const GenericAgent*>(handle);
-    return intoJPS_Point(agent->waypoint);
+    return intoJPS_Point(agent->target);
 }
 
-bool JPS_Agent_SetWayPoint(JPS_Agent handle, JPS_Point waypoint, JPS_ErrorMessage* errorMessage)
+bool JPS_Agent_SetTarget(JPS_Agent handle, JPS_Point waypoint, JPS_ErrorMessage* errorMessage)
 {
     assert(handle);
     try {
         auto agent = reinterpret_cast<GenericAgent*>(handle);
-        agent->waypoint = intoPoint(waypoint);
+        agent->target = intoPoint(waypoint);
         return true;
     } catch(const std::exception& ex) {
         if(errorMessage) {

--- a/libjupedsim/src/jupedsim.cpp
+++ b/libjupedsim/src/jupedsim.cpp
@@ -661,13 +661,6 @@ void JPS_WaitingSetProxy_Free(JPS_WaitingSetProxy handle)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// DirectSteeringProxy
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-size_t JPS_DirectSteeringProxy_GetCountTargeting(JPS_DirectSteeringProxy handle)
-{
-    assert(handle);
-    auto proxy = reinterpret_cast<DirectSteeringProxy*>(handle);
-    return proxy->CountTargeting();
-}
-
 void JPS_DirectSteeringProxy_Free(JPS_DirectSteeringProxy handle)
 {
     delete reinterpret_cast<DirectSteeringProxy*>(handle);

--- a/libjupedsim/src/jupedsim.cpp
+++ b/libjupedsim/src/jupedsim.cpp
@@ -659,7 +659,22 @@ void JPS_WaitingSetProxy_Free(JPS_WaitingSetProxy handle)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-/// WaypointProxy
+/// DirectSteeringProxy
+////////////////////////////////////////////////////////////////////////////////////////////////////
+size_t JPS_DirectSteeringProxy_GetCountTargeting(JPS_DirectSteeringProxy handle)
+{
+    assert(handle);
+    auto proxy = reinterpret_cast<DirectSteeringProxy*>(handle);
+    return proxy->CountTargeting();
+}
+
+void JPS_DirectSteeringProxy_Free(JPS_DirectSteeringProxy handle)
+{
+    delete reinterpret_cast<DirectSteeringProxy*>(handle);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// WaitPointProxy
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 size_t JPS_WaypointProxy_GetCountTargeting(JPS_WaypointProxy handle)
 {
@@ -674,7 +689,7 @@ void JPS_WaypointProxy_Free(JPS_WaypointProxy handle)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-/// WaitingSetProxy
+/// ExitProxy
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 size_t JPS_ExitProxy_GetCountTargeting(JPS_ExitProxy handle)
 {
@@ -717,6 +732,33 @@ JPS_Point JPS_Agent_GetPosition(JPS_Agent handle)
     assert(handle);
     const auto agent = reinterpret_cast<const GenericAgent*>(handle);
     return intoJPS_Point(agent->pos);
+}
+
+JPS_Point JPS_Agent_GetWayPoint(JPS_Agent handle)
+{
+    assert(handle);
+    const auto agent = reinterpret_cast<const GenericAgent*>(handle);
+    return intoJPS_Point(agent->waypoint);
+}
+
+bool JPS_Agent_SetWayPoint(JPS_Agent handle, JPS_Point waypoint, JPS_ErrorMessage* errorMessage)
+{
+    assert(handle);
+    try {
+        auto agent = reinterpret_cast<GenericAgent*>(handle);
+        agent->waypoint = intoPoint(waypoint);
+        return true;
+    } catch(const std::exception& ex) {
+        if(errorMessage) {
+            *errorMessage = reinterpret_cast<JPS_ErrorMessage>(new JPS_ErrorMessage_t{ex.what()});
+        }
+    } catch(...) {
+        if(errorMessage) {
+            *errorMessage = reinterpret_cast<JPS_ErrorMessage>(
+                new JPS_ErrorMessage_t{"Unknown internal error."});
+        }
+    }
+    return false;
 }
 
 JPS_Point JPS_Agent_GetOrientation(JPS_Agent handle)
@@ -1089,6 +1131,12 @@ JPS_StageId JPS_Simulation_AddStageWaitingSet(
     return add_stage(handle, NotifiableWaitingSetDescription{positions}, errorMessage);
 }
 
+JPS_StageId
+JPS_Simulation_AddStageDirectSteering(JPS_Simulation handle, JPS_ErrorMessage* errorMessage)
+{
+    return add_stage(handle, DirectSteeringDescription{}, errorMessage);
+}
+
 JPS_AgentId JPS_Simulation_AddGeneralizedCentrifugalForceModelAgent(
     JPS_Simulation handle,
     JPS_GeneralizedCentrifugalForceModelAgentParameters parameters,
@@ -1357,6 +1405,8 @@ JPS_StageType JPS_Simulation_GetStageType(JPS_Simulation handle, JPS_StageId id)
                 return JPS_NotifiableQueueType;
             case 3:
                 return JPS_ExitType;
+            case 4:
+                return JPS_DirectSteeringType;
         }
         UNREACHABLE();
     };
@@ -1426,6 +1476,24 @@ JUPEDSIM_API JPS_ExitProxy JPS_Simulation_GetExitProxy(
     try {
         return reinterpret_cast<JPS_ExitProxy>(
             new ExitProxy(std::get<ExitProxy>(simulation->Stage(stageId))));
+    } catch(const std::exception& ex) {
+        if(errorMessage) {
+            *errorMessage = reinterpret_cast<JPS_ErrorMessage>(new JPS_ErrorMessage_t{ex.what()});
+        }
+        return nullptr;
+    }
+}
+
+JPS_DirectSteeringProxy JPS_Simulation_GetDirectSteeringProxy(
+    JPS_Simulation handle,
+    JPS_StageId stageId,
+    JPS_ErrorMessage* errorMessage)
+{
+    assert(handle);
+    auto simulation = reinterpret_cast<Simulation*>(handle);
+    try {
+        return reinterpret_cast<JPS_DirectSteeringProxy>(
+            new DirectSteeringProxy(std::get<DirectSteeringProxy>(simulation->Stage(stageId))));
     } catch(const std::exception& ex) {
         if(errorMessage) {
             *errorMessage = reinterpret_cast<JPS_ErrorMessage>(new JPS_ErrorMessage_t{ex.what()});

--- a/libsimulator/src/GenericAgent.hpp
+++ b/libsimulator/src/GenericAgent.hpp
@@ -40,6 +40,7 @@ struct GenericAgent {
         : id(id_ != ID::Invalid ? id_ : ID{})
         , journeyId(journeyId_)
         , stageId(stageId_)
+        , waypoint(pos_)
         , pos(pos_)
         , orientation(orientation_)
         , model(std::move(model_))

--- a/libsimulator/src/GenericAgent.hpp
+++ b/libsimulator/src/GenericAgent.hpp
@@ -21,7 +21,7 @@ struct GenericAgent {
 
     // This is evaluated by the "operational level"
     Point destination{};
-    Point waypoint{};
+    Point target{};
 
     // Agent fields common for all models
     Point pos{};
@@ -40,7 +40,7 @@ struct GenericAgent {
         : id(id_ != ID::Invalid ? id_ : ID{})
         , journeyId(journeyId_)
         , stageId(stageId_)
-        , waypoint(pos_)
+        , target(pos_)
         , pos(pos_)
         , orientation(orientation_)
         , model(std::move(model_))
@@ -65,7 +65,7 @@ struct fmt::formatter<GenericAgent> {
                         agent.journeyId,
                         agent.stageId,
                         agent.destination,
-                        agent.waypoint,
+                        agent.target,
                         agent.pos,
                         agent.orientation,
                         m);
@@ -79,7 +79,7 @@ struct fmt::formatter<GenericAgent> {
                         agent.journeyId,
                         agent.stageId,
                         agent.destination,
-                        agent.waypoint,
+                        agent.target,
                         agent.pos,
                         agent.orientation,
                         m);

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -61,6 +61,15 @@ void Simulation::Iterate()
 Journey::ID Simulation::AddJourney(const std::map<BaseStage::ID, TransitionDescription>& stages)
 {
     std::map<BaseStage::ID, JourneyNode> nodes;
+    bool containsDirectSteering =
+        std::find_if(std::begin(stages), std::end(stages), [this](auto const& pair) {
+            return std::holds_alternative<DirectSteeringProxy>(Stage(pair.first));
+        }) != std::end(stages);
+
+    if(containsDirectSteering && stages.size() > 1) {
+        throw SimulationError(
+            "Journeys containing a DirectSteeringStage, may only contain this stage.");
+    }
 
     std::transform(
         std::begin(stages),

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -151,6 +151,9 @@ BaseStage::ID Simulation::AddStage(const StageDescription stageDescription)
                             "NotifiableQueue point {} not inside walkable area", point);
                     }
                 }
+            },
+            [](const DirectSteeringDescription&) -> void {
+
             }},
         stageDescription);
 

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -10,6 +10,7 @@
 #include "Stage.hpp"
 #include "Visitor.hpp"
 #include <memory>
+#include <variant>
 
 Simulation::Simulation(
     std::unique_ptr<OperationalModel>&& operationalModel,
@@ -116,6 +117,7 @@ Journey::ID Simulation::AddJourney(const std::map<BaseStage::ID, TransitionDescr
                             }},
                         desc)}};
         });
+
     auto journey = std::make_unique<Journey>(std::move(nodes));
     const auto id = journey->Id();
     _journeys.emplace(id, std::move(journey));

--- a/libsimulator/src/Simulation.hpp
+++ b/libsimulator/src/Simulation.hpp
@@ -77,6 +77,7 @@ public:
     double DT() const;
     void
     SwitchAgentJourney(GenericAgent::ID agent_id, Journey::ID journey_id, BaseStage::ID stage_id);
+    void ChangeAgentWaypoint(GenericAgent::ID agent_id, Point waypoint);
     uint64_t Iteration() const;
     std::vector<GenericAgent::ID> AgentsInRange(Point p, double distance);
     /// Returns IDs of all agents inside the defined polygon

--- a/libsimulator/src/Simulation.hpp
+++ b/libsimulator/src/Simulation.hpp
@@ -77,7 +77,6 @@ public:
     double DT() const;
     void
     SwitchAgentJourney(GenericAgent::ID agent_id, Journey::ID journey_id, BaseStage::ID stage_id);
-    void ChangeAgentWaypoint(GenericAgent::ID agent_id, Point waypoint);
     uint64_t Iteration() const;
     std::vector<GenericAgent::ID> AgentsInRange(Point p, double distance);
     /// Returns IDs of all agents inside the defined polygon

--- a/libsimulator/src/Stage.hpp
+++ b/libsimulator/src/Stage.hpp
@@ -267,7 +267,7 @@ public:
     DirectSteering() = default;
     ~DirectSteering() override = default;
     bool IsCompleted(const GenericAgent&) override { return false; };
-    Point Target(const GenericAgent& agent) override { return agent.waypoint; };
+    Point Target(const GenericAgent& agent) override { return agent.target; };
     StageProxy Proxy(Simulation* simulation) override
     {
         return DirectSteeringProxy(simulation, this);

--- a/libsimulator/src/Stage.hpp
+++ b/libsimulator/src/Stage.hpp
@@ -108,7 +108,7 @@ public:
     virtual Point Target(const GenericAgent& agent) = 0;
     virtual StageProxy Proxy(Simulation* simulation_) = 0;
     ID Id() const { return id; }
-    virtual size_t CountTargeting() const { return targeting; }
+    size_t CountTargeting() const { return targeting; }
     void IncreaseTargeting() { targeting = targeting + 1; }
     void DecreaseTargeting()
     {
@@ -272,6 +272,4 @@ public:
     {
         return DirectSteeringProxy(simulation, this);
     };
-
-    size_t CountTargeting() const override { return 1; };
 };

--- a/libsimulator/src/StageDescription.hpp
+++ b/libsimulator/src/StageDescription.hpp
@@ -8,6 +8,9 @@
 #include <variant>
 #include <vector>
 
+struct DirectSteeringDescription {
+};
+
 struct WaypointDescription {
     Point position;
     double distance;
@@ -26,6 +29,7 @@ struct NotifiableQueueDescription {
 };
 
 using StageDescription = std::variant<
+    DirectSteeringDescription,
     WaypointDescription,
     ExitDescription,
     NotifiableWaitingSetDescription,

--- a/libsimulator/src/StageManager.hpp
+++ b/libsimulator/src/StageManager.hpp
@@ -38,6 +38,9 @@ public:
                 },
                 [](const NotifiableQueueDescription& d) -> std::unique_ptr<BaseStage> {
                     return std::make_unique<NotifiableQueue>(d.slots);
+                },
+                [](const DirectSteeringDescription&) -> std::unique_ptr<BaseStage> {
+                    return std::make_unique<DirectSteering>();
                 }},
             stageDescription);
         if(stages.find(stage->Id()) != stages.end()) {
@@ -45,6 +48,7 @@ public:
         }
         const auto id = stage->Id();
         stages.emplace(id, std::move(stage));
+
         return id;
     }
 

--- a/libsimulator/src/StrategicalDesicionSystem.hpp
+++ b/libsimulator/src/StrategicalDesicionSystem.hpp
@@ -28,7 +28,7 @@ public:
     {
         for(auto& agent : agents) {
             const auto [target, id] = journeys.at(agent.journeyId)->Target(agent);
-            agent.waypoint = target;
+            agent.target = target;
             stageManager.MigrateAgent(agent.stageId, id);
             agent.stageId = id;
         }

--- a/libsimulator/src/TacticalDecisionSystem.hpp
+++ b/libsimulator/src/TacticalDecisionSystem.hpp
@@ -19,7 +19,7 @@ public:
     void Run(RoutingEngine& routingEngine, auto&& agents) const
     {
         for(auto& agent : agents) {
-            const auto dest = agent.waypoint;
+            const auto dest = agent.target;
             agent.destination = routingEngine.ComputeWaypoint(agent.pos, dest);
         }
     }

--- a/python_bindings_jupedsim/bindings_jupedsim.cpp
+++ b/python_bindings_jupedsim/bindings_jupedsim.cpp
@@ -681,11 +681,11 @@ PYBIND11_MODULE(py_jupedsim, m)
                 return intoTuple(JPS_Agent_GetOrientation(w.handle));
             })
         .def_property(
-            "waypoint",
-            [](const JPS_Agent_Wrapper& w) { return intoTuple(JPS_Agent_GetWayPoint(w.handle)); },
-            [](JPS_Agent_Wrapper& w, std::tuple<double, double> waypoint) {
+            "target",
+            [](const JPS_Agent_Wrapper& w) { return intoTuple(JPS_Agent_GetTarget(w.handle)); },
+            [](JPS_Agent_Wrapper& w, std::tuple<double, double> target) {
                 JPS_ErrorMessage errorMsg{};
-                auto success = JPS_Agent_SetWayPoint(w.handle, intoJPS_Point(waypoint), &errorMsg);
+                auto success = JPS_Agent_SetTarget(w.handle, intoJPS_Point(target), &errorMsg);
                 if(!success) {
                     auto msg = std::string(JPS_ErrorMessage_GetMessage(errorMsg));
                     JPS_ErrorMessage_Free(errorMsg);

--- a/python_bindings_jupedsim/bindings_jupedsim.cpp
+++ b/python_bindings_jupedsim/bindings_jupedsim.cpp
@@ -662,10 +662,7 @@ PYBIND11_MODULE(py_jupedsim, m)
         .def("count_targeting", [](const JPS_ExitProxy_Wrapper& w) {
             return JPS_ExitProxy_GetCountTargeting(w.handle);
         });
-    py::class_<JPS_DirectSteeringProxy_Wrapper>(m, "DirectSteeringProxy")
-        .def("count_targeting", [](const JPS_DirectSteeringProxy_Wrapper& w) {
-            return JPS_DirectSteeringProxy_GetCountTargeting(w.handle);
-        });
+    py::class_<JPS_DirectSteeringProxy_Wrapper>(m, "DirectSteeringProxy");
 
     py::class_<JPS_Agent_Wrapper>(m, "Agent")
         .def_property_readonly(

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -30,6 +30,7 @@ class Agent:
         sim.agents_in_polygon(polygon)
 
     .. note ::
+
         You need to be aware that currently there are no checks done when setting
         properties on an Agent instance. For example it is possible to set an Agent position
         outside the walkable area of the Simulation resulting in a crash.
@@ -68,7 +69,21 @@ class Agent:
         return self._obj.orientation
 
     @property
-    def waypoint(self):
+    def waypoint(self) -> tuple[float, float]:
+        """Current waypoint the agent targets.
+
+        Can be used to directly steer an agent towards the given coordinate.
+        This will bypass the strategical and tactical level, but the operational level
+        will still be active.
+
+        .. important::
+
+            If the agent is not in a Journey with a DirectSteering stage, any change will be
+            ignored.
+
+        Returns:
+            Current target of the agent.
+        """
         return self._obj.waypoint
 
     @waypoint.setter

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -69,8 +69,8 @@ class Agent:
         return self._obj.orientation
 
     @property
-    def waypoint(self) -> tuple[float, float]:
-        """Current waypoint the agent targets.
+    def target(self) -> tuple[float, float]:
+        """Current target of the agent.
 
         Can be used to directly steer an agent towards the given coordinate.
         This will bypass the strategical and tactical level, but the operational level
@@ -84,11 +84,11 @@ class Agent:
         Returns:
             Current target of the agent.
         """
-        return self._obj.waypoint
+        return self._obj.target
 
-    @waypoint.setter
-    def waypoint(self, waypoint: tuple[float, float]):
-        self._obj.waypoint = waypoint
+    @target.setter
+    def target(self, target: tuple[float, float]):
+        self._obj.target = target
 
     @property
     def model(

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -68,6 +68,14 @@ class Agent:
         return self._obj.orientation
 
     @property
+    def waypoint(self):
+        return self._obj.waypoint
+
+    @waypoint.setter
+    def waypoint(self, waypoint: tuple[float, float]):
+        self._obj.waypoint = waypoint
+
+    @property
     def model(
         self,
     ) -> GeneralizedCentrifugalForceModelState | CollisionFreeSpeedModelState:

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -81,6 +81,11 @@ class Agent:
             If the agent is not in a Journey with a DirectSteering stage, any change will be
             ignored.
 
+        .. important::
+
+            When setting the target, the given coordinates must lie within the walkable area.
+            Otherwise, an error will be thrown at the next iteration call.
+
         Returns:
             Current target of the agent.
         """

--- a/python_modules/jupedsim/jupedsim/simulation.py
+++ b/python_modules/jupedsim/jupedsim/simulation.py
@@ -178,6 +178,19 @@ class Simulation:
         return self._obj.add_exit_stage(exit_geometry.boundary())
 
     def add_direct_steering_stage(self) -> int:
+        """Add an direct steering stage to the simulation.
+
+        This stage allows a direct control of the target the agent is walking to.
+        Thus, it will bypass the tactical and stragecial level of the simulation, but the
+        operational level will still be active.
+
+        .. important::
+
+            A direct steering stage can only be used if it is the only stage in a Journey.
+
+        Returns:
+            Id of the added direct steering stage.
+        """
         return self._obj.add_direct_steering_stage()
 
     def add_journey(self, journey: JourneyDescription) -> int:

--- a/python_modules/jupedsim/jupedsim/simulation.py
+++ b/python_modules/jupedsim/jupedsim/simulation.py
@@ -177,6 +177,9 @@ class Simulation:
         exit_geometry = build_geometry(polygon)
         return self._obj.add_exit_stage(exit_geometry.boundary())
 
+    def add_direct_steering_stage(self) -> int:
+        return self._obj.add_direct_steering_stage()
+
     def add_journey(self, journey: JourneyDescription) -> int:
         return self._obj.add_journey(journey._obj)
 


### PR DESCRIPTION
This change will allow direct steering of agents, they will move towards

- [x] check if `DirectSteering`-Stage is the only one in a Journey, else throw error
- [x] ~~check if Agent is in a Journey with `DirectSteering` when setting waypoint, else throw error~~ Currently not possible, added notes to documentation.
- [x] ~~check if new waypoint in walkable area, else throw error.~~ Error will be thrown by the Routing Engine
- [x] rename `GenericAgent::waypoint` to `target`?