### PR TITLE
Fix pypi upload

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -310,6 +310,7 @@ jobs:
         with:
           pattern: python-packages-*
           merge-multiple: true
+          path: dist
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Upload action now downloads packages to `dist/`, this is the default pickup location of the publish action