### PR TITLE
disabling search state update to get all paths

### DIFF
--- a/libsimulator/src/RoutingEngine.cpp
+++ b/libsimulator/src/RoutingEngine.cpp
@@ -389,16 +389,16 @@ RoutingEngine::ComputeAllConsideredPaths(Point currentPosition, Point destinatio
 
             // TODO(kkratz): replace this find on unsorted vector with something with a better
             // runtime
-            if(auto iter = std::find_if(
-                   std::begin(open_states),
-                   std::end(open_states),
-                   [t2](const auto& s) { return s->id == t2; });
-               iter != std::end(open_states)) {
-                if(auto& s = *iter; s->g_value > g_value) {
-                    s->g_value = g_value;
-                    s->parent = current_state.get();
-                    LOG_DEBUG("updated \t{}", *s);
-                }
+            // if(auto iter = std::find_if(
+            //        std::begin(open_states),
+            //        std::end(open_states),
+            //        [t2](const auto& s) { return s->id == t2; });
+            //    iter != std::end(open_states)) {
+            //     if(auto& s = *iter; s->g_value > g_value) {
+            //         s->g_value = g_value;
+            //         s->parent = current_state.get();
+            //         LOG_DEBUG("updated \t{}", *s);
+            //     }
 
                 // } else if(auto iter = closed_states.find(target); iter !=
                 // std::end(closed_states)) {
@@ -408,11 +408,11 @@ RoutingEngine::ComputeAllConsideredPaths(Point currentPosition, Point destinatio
                 //         open_states.push_back(s);
                 //         closed_states.erase(s->id);
                 //     }
-            } else {
+            // } else {
                 known_faces.try_emplace(target, known_faces.size() + 1);
                 sss.emplace_back(new SearchState{g_value, h_value, target, current_state.get()});
                 open_states.emplace_back(sss.back());
-            }
+            // }
         }
     }
 

--- a/libsimulator/src/RoutingEngine.cpp
+++ b/libsimulator/src/RoutingEngine.cpp
@@ -307,6 +307,13 @@ RoutingEngine::ComputeAllConsideredPaths(Point currentPosition, Point destinatio
         open_states.pop_back();
         // closed_states.insert(std::make_pair(current_state->id, current_state));
 
+        if(current_state->f_value() > path_length) {
+            LOG_DEBUG("DONE");
+            // This search nodes f-value already excedes our paths length, and since the f-value is
+            // underestimation of the path length the excat path cannot be shorter than what we have
+            return paths;
+        }
+
         if(current_state->id == to) {
             LOG_DEBUG("FOUND PATH");
             // Unlike in A* this is only a first candidate solution
@@ -322,13 +329,7 @@ RoutingEngine::ComputeAllConsideredPaths(Point currentPosition, Point destinatio
             if(found_path_length < path_length) {
                 path_length = found_path_length;
             }
-        }
-
-        if(current_state->f_value() > path_length) {
-            LOG_DEBUG("DONE");
-            // This search nodes f-value already excedes our paths length, and since the f-value is
-            // underestimation of the path length the excat path cannot be shorter than what we have
-            return paths;
+            continue;
         }
 
         // Generate successors


### PR DESCRIPTION
I disabled the search state update only in the ComputeAllConsiderePaths function to show the effect. For the final fix it needs to be transferred to the ComputeAllWaypoints as well of course.