### PR TITLE
GCFM miscalculations when not initialised properly

### DIFF
--- a/libjupedsim/include/jupedsim/generalized_centrifugal_force_model.h
+++ b/libjupedsim/include/jupedsim/generalized_centrifugal_force_model.h
@@ -242,7 +242,7 @@ typedef struct JPS_GeneralizedCentrifugalForceModelAgentParameters {
      * Orientation vector of the agent.
      * The orientation vector will internally be normalized.
      */
-    JPS_Point orientation{0, 0};
+    JPS_Point orientation{1, 0};
     /**
      * Defines the journey this agent will take use
      */

--- a/libjupedsim/test/TestJupedsim.cpp
+++ b/libjupedsim/test/TestJupedsim.cpp
@@ -64,7 +64,7 @@ TEST(OperationalModel, DefaultsOfGeneralizedCentrifugalForceModelAgentParameters
     ASSERT_DOUBLE_EQ(agentParameters.e0.y, 0);
     ASSERT_DOUBLE_EQ(agentParameters.position.x, 0);
     ASSERT_DOUBLE_EQ(agentParameters.position.y, 0);
-    ASSERT_DOUBLE_EQ(agentParameters.orientation.x, 0);
+    ASSERT_DOUBLE_EQ(agentParameters.orientation.x, 1);
     ASSERT_DOUBLE_EQ(agentParameters.orientation.y, 0);
     ASSERT_DOUBLE_EQ(agentParameters.journeyId, 0);
     ASSERT_DOUBLE_EQ(agentParameters.stageId, 0);

--- a/libsimulator/src/Ellipse.cpp
+++ b/libsimulator/src/Ellipse.cpp
@@ -3,18 +3,42 @@
 #include "Ellipse.hpp"
 #include "Macros.hpp"
 
-// ellipse  semi-axis in the direction of the velocity
+/**
+ * @brief Calculates the semi-major axis (EA) of an ellipse based on the given speed.
+ *
+ * The ellipse adapts dynamically depending on the agent's speed. This method computes
+ * the semi-axis length in the direction of movement, reflecting how the ellipse
+ * elongates as speed increases.
+ *
+ * @param speed The current speed of the object (must be non-negative).
+ * @return The computed semi-axis length in the velocity direction.
+ *
+ */
 double Ellipse::GetEA(double speed) const
 {
     return Amin + speed * Av;
 }
 
-// ellipse semi-axis in the orthogonal direction of the velocity
+/**
+ * @brief Calculates the semi-minor axis (EB) of an ellipse orthogonal to the direction of velocity.
+ *
+ * This method computes the ellipse's semi-axis length perpendicular to the object's movement,
+ * allowing the ellipse to contract or expand based on the provided scaling factor.
+ *
+ * @param scale A scaling factor typically in the range \f$ [0, 1] \f$.
+ *        - \f$ \text{scale} = 0 \f$ → returns \f$ B_{\text{max}} \f$.
+ *        - \f$ \text{scale} = 1 \f$ → returns \f$ B_{\text{min}} \f$.
+ * @return The computed semi-axis length orthogonal to the velocity direction.
+ *
+ * @note Values of `scale` outside the \f$ [0, 1] \f$ range may produce unexpected results.
+ * @warning No input validation is performed on the `scale` parameter.
+ */
 double Ellipse::GetEB(double scale) const
 {
     const double deltaB = Bmax - Bmin;
     return Bmax - deltaB * scale;
 }
+
 
 double Ellipse::EffectiveDistanceToEllipse(
     const Ellipse& E2,
@@ -27,19 +51,16 @@ double Ellipse::EffectiveDistanceToEllipse(
     const Point& orientation_first,
     const Point& orientation_second) const
 {
-    Point R1, R2;
-    Point E1inE2, // center of E1 in coordinate system of E2
-        E2inE1;
-    E2inE1 = center_second.TransformToEllipseCoordinates(
-        center_first, orientation_first.x, orientation_first.y);
-    E1inE2 = center_first.TransformToEllipseCoordinates(
-        center_second, orientation_second.x, orientation_second.y);
-    // distance between centers of E1 and E2
-    const auto dist = (center_first - center_second).Norm();
-    R1 = this->PointOnEllipse(E2inE1, scale_first, center_first, speed_first, orientation_first);
-    R2 = E2.PointOnEllipse(E1inE2, scale_second, center_second, speed_second, orientation_second);
-    // effective distance
-    return dist - (center_first - R1).Norm() - (center_second - R2).Norm();
+    // Transform centers into each other's coordinate systems using orientation as cos(φ) and sin(φ)
+    Point E2inE1 = center_second.TransformToEllipseCoordinates(center_first, orientation_first.x, orientation_first.y);
+    Point E1inE2 = center_first.TransformToEllipseCoordinates(center_second, orientation_second.x, orientation_second.y);
+
+    // Find the closest points on each ellipse
+    Point R1 = this->PointOnEllipse(E2inE1, scale_first, center_first, speed_first, orientation_first);
+    Point R2 = E2.PointOnEllipse(E1inE2, scale_second, center_second, speed_second, orientation_second);
+
+    // Compute the shortest distance between the closest points
+    return (R1 - R2).Norm();
 }
 
 // input: P is a point in the ellipse world.

--- a/libsimulator/src/Ellipse.cpp
+++ b/libsimulator/src/Ellipse.cpp
@@ -3,58 +3,51 @@
 #include "Ellipse.hpp"
 #include "Macros.hpp"
 
-/**
- * @brief Calculates the semi-major axis (EA) of an ellipse based on the given speed.
- *
- * The ellipse adapts dynamically depending on the agent's speed. This method computes
- * the semi-axis length in the direction of movement, reflecting how the ellipse
- * elongates as speed increases.
- *
- * @param speed The current speed of the object (must be non-negative).
- * @return The computed semi-axis length in the velocity direction.
- *
- */
+/// Calculates the semi-major axis (EA) of an ellipse based on the given speed.
+///
+/// The ellipse adapts dynamically depending on the agent's speed. This method computes
+/// the semi-axis length in the direction of movement, reflecting how the ellipse
+/// elongates as speed increases.
+///
+/// @param speed The current speed of the object (must be non-negative).
+/// @return The computed semi-axis length in the velocity direction.
 double Ellipse::GetEA(double speed) const
 {
     return Amin + speed * Av;
 }
 
-/**
- * @brief Calculates the semi-minor axis (EB) of an ellipse orthogonal to the direction of velocity.
- *
- * This method computes the ellipse's semi-axis length perpendicular to the object's movement,
- * allowing the ellipse to contract or expand based on the provided scaling factor.
- *
- * @param scale A scaling factor typically in the range \f$ [0, 1] \f$.
- *        - \f$ \text{scale} = 0 \f$ → returns \f$ B_{\text{max}} \f$.
- *        - \f$ \text{scale} = 1 \f$ → returns \f$ B_{\text{min}} \f$.
- * @return The computed semi-axis length orthogonal to the velocity direction.
- *
- * @note Values of `scale` outside the \f$ [0, 1] \f$ range may produce unexpected results.
- * @warning No input validation is performed on the `scale` parameter.
- */
+/// Calculates the semi-minor axis (EB) of an ellipse orthogonal to the direction of velocity.
+///
+/// This method computes the ellipse's semi-axis length perpendicular to the object's movement,
+/// allowing the ellipse to contract or expand based on the provided scaling factor.
+///
+/// @param scale A scaling factor typically in the range \f$ [0, 1] \f$.
+///        - \f$ \text{scale} = 0 \f$ → returns \f$ B_{\text{max}} \f$.
+///        - \f$ \text{scale} = 1 \f$ → returns \f$ B_{\text{min}} \f$.
+/// @return The computed semi-axis length orthogonal to the velocity direction.
+///
+/// @note Values of `scale` outside the \f$ [0, 1] \f$ range may produce unexpected results.
+/// @warning No input validation is performed on the `scale` parameter.
 double Ellipse::GetEB(double scale) const
 {
     const double deltaB = Bmax - Bmin;
     return Bmax - deltaB * scale;
 }
 
-/**
- * @brief Calculates the effective distance between two ellipses.
- *
- * This function computes the shortest distance between two ellipses. It does so by:
- *
- * 1. **Coordinate Transformation:**
- *    Transforms the center of each ellipse into the local coordinate system of the other
- *    using their orientation vectors.
- *
- * 2. **Closest Point Determination:**
- *    Identifies the closest point on each ellipse to the other ellipse in their respective
- *    coordinate systems.
- *
- * 3. **Effective Distance Calculation:**
- *    Calculates the Euclidean distance between these two closest points on the ellipses.
- */
+/// Calculates the effective distance between two ellipses.
+///
+/// This function computes the shortest distance between two ellipses. It does so by:
+///
+/// 1. **Coordinate Transformation:**
+///    Transforms the center of each ellipse into the local coordinate system of the other
+///    using their orientation vectors.
+///
+/// 2. **Closest Point Determination:**
+///    Identifies the closest point on each ellipse to the other ellipse in their respective
+///    coordinate systems.
+///
+/// 3. **Effective Distance Calculation:**
+///    Calculates the Euclidean distance between these two closest points on the ellipses.
 double Ellipse::EffectiveDistanceToEllipse(
     const Ellipse& E2,
     Point center_first,
@@ -79,22 +72,19 @@ double Ellipse::EffectiveDistanceToEllipse(
     return (R1 - R2).Norm();
 }
 
-/**
- * @brief Computes the point on the ellipse boundary along the line from the ellipse center to point
- * P.
- *
- * Given a point \( P \) in the local coordinate system of the ellipse, this function finds the
- * corresponding point on the ellipse that lies on the same line extending from the center through
- * \( P \).
- *
- * **Behavior:**
- * - If \( P \) is very close to the ellipse center, it defaults to returning the point \((a, 0)\)
- * on the ellipse.
- * - Otherwise, it scales the direction from the center to \( P \) by the ellipse’s semi-major and
- * semi-minor axes.
- *
- * @return Point on the ellipse boundary, transformed into the global coordinate system.
- */
+/// Computes the point on the ellipse boundary along the line from the ellipse center to point P.
+///
+/// Given a point \( P \) in the local coordinate system of the ellipse, this function finds the
+/// corresponding point on the ellipse that lies on the same line extending from the center through
+/// \( P \).
+///
+/// **Behavior:**
+/// - If \( P \) is very close to the ellipse center, it defaults to returning the point \((a, 0)\)
+/// on the ellipse.
+/// - Otherwise, it scales the direction from the center to \( P \) by the ellipse’s semi-major and
+/// semi-minor axes.
+///
+/// @return Point on the ellipse boundary, transformed into the global coordinate system.
 Point Ellipse::PointOnEllipse(
     const Point& P,
     double scale,

--- a/libsimulator/src/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/GeneralizedCentrifugalForceModel.cpp
@@ -473,12 +473,16 @@ double GeneralizedCentrifugalForceModel::AgentToAgentSpacing(
     const Ellipse E2{model2.Av, model2.AMin, model2.BMax, model2.BMin};
     const auto v0_1 = model1.v0;
     const auto v0_2 = model2.v0;
+    // Avoid division by zero by setting scale to 1 when v0 is 0
+    const double scale1 = (v0_1 == 0.0) ? 1.0 : model1.speed / v0_1;
+    const double scale2 = (v0_2 == 0.0) ? 1.0 : model2.speed / v0_2;
+
     return E1.EffectiveDistanceToEllipse(
         E2,
         agent1.pos,
         agent2.pos,
-        model1.speed / v0_1,
-        model2.speed / v0_2,
+        scale1,
+        scale2,
         model1.speed,
         model2.speed,
         agent1.orientation,

--- a/libsimulator/src/GenericAgent.hpp
+++ b/libsimulator/src/GenericAgent.hpp
@@ -27,7 +27,7 @@ struct GenericAgent {
 
     // Agent fields common for all models
     Point pos{};
-    Point orientation{1, 0};
+    Point orientation{};
 
     using Model = std::variant<
         GeneralizedCentrifugalForceModelData,

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -1,7 +1,6 @@
 // Copyright © 2012-2024 Forschungszentrum Jülich GmbH
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "Point.hpp"
-#include <cassert>
 
 #include <Logger.hpp>
 #include <limits>

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -6,6 +6,15 @@
 #include <Logger.hpp>
 #include <limits>
 
+bool Point::isInvalidOrientation() const
+{
+    if((std::abs(x) < 1e-6 && std::abs(y) < 1e-6) || (std::abs(NormSquare() - 1.0) > 1e-6)) {
+        LOG_WARNING("Orientation vector ({}, {}) is not normalized, correcting it.", x, y);
+        return true;
+    }
+    return false;
+}
+
 double Point::Norm() const
 {
     return sqrt(NormSquare());
@@ -40,14 +49,6 @@ std::tuple<double, Point> Point::NormAndNormalized() const
  */
 Point Point::TransformToEllipseCoordinates(const Point& center, double cphi, double sphi) const
 {
-    // if((std::abs(cphi) < 1e-6 && std::abs(sphi) < 1e-6) ||
-    //    std::abs(cphi * cphi + sphi * sphi - 1.0) > 1e-6) {
-    //     throw std::invalid_argument(
-    //         "Invalid rotation inputs: vector is zero or not normalized (cphi^2 + sphi^2 != 1). "
-    //         "Values: cphi=" +
-    //         std::to_string(cphi) + ", sphi=" + std::to_string(sphi));
-    // }
-
     Point p = Point(x, y);
     return (p - center).Rotate(cphi, -sphi);
 }
@@ -67,13 +68,6 @@ Point Point::TransformToEllipseCoordinates(const Point& center, double cphi, dou
  */
 Point Point::TransformToCartesianCoordinates(const Point& center, double cphi, double sphi) const
 {
-    // if((std::abs(cphi) < 1e-6 && std::abs(sphi) < 1e-6) ||
-    //    std::abs(cphi * cphi + sphi * sphi - 1.0) > 1e-6) {
-    //     throw std::invalid_argument(
-    //         "Invalid rotation inputs: vector is zero or not normalized (cphi^2 + sphi^2 != 1). "
-    //         "Values: cphi=" +
-    //         std::to_string(cphi) + ", sphi=" + std::to_string(sphi));
-    // }
 
     Point p = Point(x, y);
     return (p.Rotate(cphi, sphi) + center);

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -40,12 +40,13 @@ std::tuple<double, Point> Point::NormAndNormalized() const
  */
 Point Point::TransformToEllipseCoordinates(const Point& center, double cphi, double sphi) const
 {
-
-    if((std::abs(cphi) < 1e-6 && std::abs(sphi) < 1e-6) ||
-       std::abs(cphi * cphi + sphi * sphi - 1.0) > 1e-6) {
-        throw std::invalid_argument("Point::TransformToEllipseCoordinates Invalid rotation inputs: "
-                                    "vector is zero or not normalized (cphi^2 + sphi^2 != 1)");
-    }
+    // if((std::abs(cphi) < 1e-6 && std::abs(sphi) < 1e-6) ||
+    //    std::abs(cphi * cphi + sphi * sphi - 1.0) > 1e-6) {
+    //     throw std::invalid_argument(
+    //         "Invalid rotation inputs: vector is zero or not normalized (cphi^2 + sphi^2 != 1). "
+    //         "Values: cphi=" +
+    //         std::to_string(cphi) + ", sphi=" + std::to_string(sphi));
+    // }
 
     Point p = Point(x, y);
     return (p - center).Rotate(cphi, -sphi);
@@ -66,12 +67,13 @@ Point Point::TransformToEllipseCoordinates(const Point& center, double cphi, dou
  */
 Point Point::TransformToCartesianCoordinates(const Point& center, double cphi, double sphi) const
 {
-
-    if((std::abs(cphi) < 1e-6 && std::abs(sphi) < 1e-6) ||
-       std::abs(cphi * cphi + sphi * sphi - 1.0) > 1e-6) {
-        throw std::invalid_argument("Point::TransformToEllipseCoordinates Invalid rotation inputs: "
-                                    "vector is zero or not normalized (cphi^2 + sphi^2 != 1)");
-    }
+    // if((std::abs(cphi) < 1e-6 && std::abs(sphi) < 1e-6) ||
+    //    std::abs(cphi * cphi + sphi * sphi - 1.0) > 1e-6) {
+    //     throw std::invalid_argument(
+    //         "Invalid rotation inputs: vector is zero or not normalized (cphi^2 + sphi^2 != 1). "
+    //         "Values: cphi=" +
+    //         std::to_string(cphi) + ", sphi=" + std::to_string(sphi));
+    // }
 
     Point p = Point(x, y);
     return (p.Rotate(cphi, sphi) + center);

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -6,13 +6,10 @@
 #include <Logger.hpp>
 #include <limits>
 
-bool Point::isInvalidOrientation() const
+bool Point::isZeroLength() const
 {
-    if((std::abs(x) < 1e-6 && std::abs(y) < 1e-6) || (std::abs(NormSquare() - 1.0) > 1e-6)) {
-        LOG_WARNING("Orientation vector {}, {} is not normalized, correcting it.", x, y);
-        return true;
-    }
-    return false;
+    constexpr double epsilon = 1e-6;
+    return (std::abs(x) < epsilon && std::abs(y) < epsilon);
 }
 
 double Point::Norm() const

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -9,7 +9,7 @@
 bool Point::isInvalidOrientation() const
 {
     if((std::abs(x) < 1e-6 && std::abs(y) < 1e-6) || (std::abs(NormSquare() - 1.0) > 1e-6)) {
-        LOG_WARNING("Orientation vector ({}, {}) is not normalized, correcting it.", x, y);
+        LOG_WARNING("Orientation vector {}, {} is not normalized, correcting it.", x, y);
         return true;
     }
     return false;

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -70,7 +70,7 @@ Point Point::TransformToCartesianCoordinates(const Point& center, double cphi, d
 }
 
 /**
- * Helper method to rotate a point around the origin counterclockwise
+ * CCW rotate Point (interpreted as vector) around origin.
  * @param ctheta Cosine of rotation angle
  * @param stetha Sine of rotation angle
  * @return Rotated point

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -40,9 +40,13 @@ std::tuple<double, Point> Point::NormAndNormalized() const
  */
 Point Point::TransformToEllipseCoordinates(const Point& center, double cphi, double sphi) const
 {
-    assert(
-        std::abs(cphi * cphi + sphi * sphi - 1.0) < 1e-6 &&
-        "Invalid rotation inputs: cphi^2 + sphi^2 != 1");
+
+    if((std::abs(cphi) < 1e-6 && std::abs(sphi) < 1e-6) ||
+       std::abs(cphi * cphi + sphi * sphi - 1.0) > 1e-6) {
+        throw std::invalid_argument("Point::TransformToEllipseCoordinates Invalid rotation inputs: "
+                                    "vector is zero or not normalized (cphi^2 + sphi^2 != 1)");
+    }
+
     Point p = Point(x, y);
     return (p - center).Rotate(cphi, -sphi);
 }
@@ -62,9 +66,13 @@ Point Point::TransformToEllipseCoordinates(const Point& center, double cphi, dou
  */
 Point Point::TransformToCartesianCoordinates(const Point& center, double cphi, double sphi) const
 {
-    assert(
-        std::abs(cphi * cphi + sphi * sphi - 1.0) < 1e-6 &&
-        "Invalid rotation inputs: cphi^2 + sphi^2 != 1");
+
+    if((std::abs(cphi) < 1e-6 && std::abs(sphi) < 1e-6) ||
+       std::abs(cphi * cphi + sphi * sphi - 1.0) > 1e-6) {
+        throw std::invalid_argument("Point::TransformToEllipseCoordinates Invalid rotation inputs: "
+                                    "vector is zero or not normalized (cphi^2 + sphi^2 != 1)");
+    }
+
     Point p = Point(x, y);
     return (p.Rotate(cphi, sphi) + center);
 }

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -1,8 +1,7 @@
 // Copyright © 2012-2024 Forschungszentrum Jülich GmbH
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "Point.hpp"
-
-#include "Macros.hpp"
+#include <cassert>
 
 #include <Logger.hpp>
 #include <limits>
@@ -26,102 +25,56 @@ std::tuple<double, Point> Point::NormAndNormalized() const
         return std::make_tuple(0.0, Point(0.0, 0.0));
 }
 
-/* Transformiert die "normalen" Koordinaten in Koordinaten der Ellipse
- * dazu verschieben des Koordinaten Ursprungs in Center und anschliessend drehen um phi
- * alle Punkte müssen in "normalen" Koordinaten gegeben sein
- * center: Center der Ellipse in deren System transformiert werden soll
- * phi: Winkel der Ellipse in deren System transformiert werden soll
- * */
-
-/*coordinate transformation of the point P(x,y) expressed in coord system S1 to a new coord. sys S2
-
-           A
-           *
-         |     S_2
-     \   |   /
- |    \  |  /
- |     \ | /^phi
- | yc___\ /_)_________ S_3
- |       O1
- |       |
- |       |
- |       xc
- |
- |___________________________
-O
-S_1
-
-
-////////////////////////////////////
-S_1 is cartesian coordinate system!!
-////////////////////////////////////
-
-  input:
-  - (x,y)        :  coordinates of the point A in S_1
-  - (xc,yc)      : coordinate of the center in the  S_1 (Center of Ellipse)
-  - phi          : angle between the S_1 and S_2
-
-  output:
-  +  (xnew,ynew) : new coordinate of the point A in the coord. sys S2
-
-OA = OO1 + O1A
-
- [x ; y] = [xc ; yc] +  [x_3 ; y_3]   : (1) ( with [x_i ; y_i] coordinats of P in S_i and i in
-{1,2,3} )
-
-[x_2 ; y_2] = M(phi) * [x_3 ; y_3]  : (2)
-
-
-(1) in (2)--->
-
--->  [x_2 ; y_2] = M(phi) * ([x ; y] - [xc ; yc])
-
-
-
-after rotation:
-OC = OO1 +O1C
-OC  = -O1O +O1C
-
-xnew = -xc + x
-
-*/
+/**
+ * Transforms a point from the global Cartesian coordinate system (S_1)
+ * into the ellipse-local coordinate system (S_2).
+ *
+ * Steps:
+ * 1. **Translation:** Move the point relative to the ellipse center.
+ * 2. **Rotation:** Rotate by angle -phi to align with S_2 axes.
+ *
+ * @param center  The center of the ellipse in Cartesian coordinates (xc, yc)
+ * @param cphi    Cosine of rotation angle phi
+ * @param sphi    Sine of rotation angle phi
+ * @return        Point transformed into the ellipse-local frame (S_2)
+ */
 Point Point::TransformToEllipseCoordinates(const Point& center, double cphi, double sphi) const
 {
+    assert(
+        std::abs(cphi * cphi + sphi * sphi - 1.0) < 1e-6 &&
+        "Invalid rotation inputs: cphi^2 + sphi^2 != 1");
     Point p = Point(x, y);
     return (p - center).Rotate(cphi, -sphi);
 }
-
-/*
-This is the reverse funktion of TransformToEllipseCoordinates(),
-where the coord. of a point are transformated to cart. coord.
-
- input:
-  - (x,y)        :  coordinates of the point P in S_2
-  - (xc,yc)      : coordinate of the center in the  S_1 (Center of Ellipse)
-  - phi          : angle between the S_1 and S_2
-
-  output:
-  +  (xnew,ynew) : new coordinate of the point P in the coord. sys S_1
-
-[x_2 ; y_2] = M(phi) * ([x ; y] - [xc ; yc]) (see comments in CoordTransToEllipse() )
-
-
-----> [x ; y] =  M(-phi) * [x_2 ; y_2] +  [xc ; yc]
-
-*/
-
+/**
+ * Transforms coordinates from ellipse-local system (S_2) back to Cartesian system (S_1).
+ * This is the inverse operation of TransformToEllipseCoordinates().
+ *
+ * The transformation follows these steps:
+ * 1. Take point P(x,y) in ellipse system S_2
+ * 2. Rotate by -phi to align with Cartesian axes: M(-phi) * [x_2 ; y_2]
+ * 3. Add ellipse center coordinates to translate: + [xc ; yc]
+ *
+ * @param center The ellipse center coordinates (xc,yc) in Cartesian system S_1
+ * @param cphi   cos(phi), where phi is the angle between S_1 and S_2
+ * @param sphi   sin(phi)
+ * @return       Point in Cartesian coordinates (S_1)
+ */
 Point Point::TransformToCartesianCoordinates(const Point& center, double cphi, double sphi) const
 {
+    assert(
+        std::abs(cphi * cphi + sphi * sphi - 1.0) < 1e-6 &&
+        "Invalid rotation inputs: cphi^2 + sphi^2 != 1");
     Point p = Point(x, y);
     return (p.Rotate(cphi, sphi) + center);
 }
 
-/*rotate a two-dimensional vector by an angle of theta
-
-Rotation-matrix=[cos(theta)  -sin(theta)]
-                [ sin(theta)  cos(theta)]
-
-*/
+/**
+ * Helper method to rotate a point around the origin counterclockwise
+ * @param ctheta Cosine of rotation angle
+ * @param stetha Sine of rotation angle
+ * @return Rotated point
+ */
 Point Point::Rotate(double ctheta, double stheta) const
 {
     return Point(x * ctheta - y * stheta, x * stheta + y * ctheta);

--- a/libsimulator/src/Point.hpp
+++ b/libsimulator/src/Point.hpp
@@ -17,6 +17,8 @@ public:
 public:
     Point(double x = 0, double y = 0) : x(x), y(y) {};
 
+    bool isInvalidOrientation() const;
+
     /// Norm
     double Norm() const;
 

--- a/libsimulator/src/Point.hpp
+++ b/libsimulator/src/Point.hpp
@@ -17,7 +17,7 @@ public:
 public:
     Point(double x = 0, double y = 0) : x(x), y(y) {};
 
-    bool isInvalidOrientation() const;
+    bool isZeroLength() const;
 
     /// Norm
     double Norm() const;

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -8,7 +8,6 @@
 #include "OperationalModel.hpp"
 #include "Stage.hpp"
 #include "Visitor.hpp"
-#include <Logger.hpp>
 
 #include <memory>
 #include <variant>
@@ -186,12 +185,12 @@ GenericAgent::ID Simulation::AddAgent(GenericAgent&& agent)
         throw SimulationError("Unknown journey id: {}", agent.journeyId);
     }
 
-    if(agent.orientation.isZeroLength()) {
-        throw SimulationError("Orientation is invalid: {}. Length should be 1.", agent.orientation);
-    }
-
     if(!_journeys.at(agent.journeyId)->ContainsStage(agent.stageId)) {
         throw SimulationError("Unknown stage id: {}", agent.stageId);
+    }
+
+    if(agent.orientation.isZeroLength()) {
+        throw SimulationError("Orientation is invalid: {}. Length should be 1.", agent.orientation);
     }
 
     agent.orientation = agent.orientation.Normalized();

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -189,9 +189,11 @@ GenericAgent::ID Simulation::AddAgent(GenericAgent&& agent)
         throw SimulationError("Unknown stage id: {}", agent.stageId);
     }
 
-    if(agent.orientation.isZeroLength()) {
-        throw SimulationError("Orientation is invalid: {}. Length should be 1.", agent.orientation);
-    }
+    if(std::holds_alternative<GeneralizedCentrifugalForceModelData>(agent.model))
+        if(agent.orientation.isZeroLength()) {
+            throw SimulationError(
+                "Orientation is invalid: {}. Length should be 1.", agent.orientation);
+        }
 
     agent.orientation = agent.orientation.Normalized();
     _operationalDecisionSystem.ValidateAgent(agent, _neighborhoodSearch, *_geometry);

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -186,28 +186,17 @@ GenericAgent::ID Simulation::AddAgent(GenericAgent&& agent)
         throw SimulationError("Unknown journey id: {}", agent.journeyId);
     }
 
-    Point targetPoint = std::get<0>(_journeys.at(agent.journeyId)->Target(agent));
-    if((targetPoint - agent.pos).Norm() < 1e-6) {
-        LOG_WARNING(
-            "Agent's position ({}, {})  is the same as the target ({}, {}). Set defaul orientation "
-            "to (1,0)",
-            agent.pos.x,
-            agent.pos.y,
-            targetPoint.x,
-            targetPoint.y);
-        agent.orientation = Point(1.0, 0.0);
-    }
-
     if(agent.orientation.isInvalidOrientation()) {
-        Point direction = (targetPoint - agent.pos).Normalized();
-        agent.orientation = direction;
+        throw SimulationError("Orientation is invalid: {}. Length should be 1.", agent.orientation);
     }
-    agent.orientation = agent.orientation.Normalized();
-    _operationalDecisionSystem.ValidateAgent(agent, _neighborhoodSearch, *_geometry);
 
     if(!_journeys.at(agent.journeyId)->ContainsStage(agent.stageId)) {
         throw SimulationError("Unknown stage id: {}", agent.stageId);
     }
+
+    agent.orientation = agent.orientation.Normalized();
+    _operationalDecisionSystem.ValidateAgent(agent, _neighborhoodSearch, *_geometry);
+
     _stageManager.HandleNewAgent(agent.stageId);
     _agents.emplace_back(std::move(agent));
     _neighborhoodSearch.AddAgent(_agents.back());

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -186,7 +186,7 @@ GenericAgent::ID Simulation::AddAgent(GenericAgent&& agent)
         throw SimulationError("Unknown journey id: {}", agent.journeyId);
     }
 
-    if(agent.orientation.isInvalidOrientation()) {
+    if(agent.orientation.isZeroLength()) {
         throw SimulationError("Orientation is invalid: {}. Length should be 1.", agent.orientation);
     }
 

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -186,8 +186,11 @@ GenericAgent::ID Simulation::AddAgent(GenericAgent&& agent)
 
     Point targetPoint = std::get<0>(_journeys.at(agent.journeyId)->Target(agent));
     if((targetPoint - agent.pos).Norm() < 1e-6) {
-        throw SimulationError(
-            "Can not add Agent. Agent's position {} is same as target {}", agent.pos, targetPoint);
+        std::cerr << "Warning: Agent's position " << agent.pos.x << ", " << agent.pos.y
+                  << " is the same as the target " << targetPoint.x << ", " << targetPoint.y
+                  << ". Setting default direction to (1, 0)." << std::endl;
+
+        agent.orientation = Point(1.0, 0.0);
     }
     if(std::abs(agent.orientation.x) < 1e-6 && std::abs(agent.orientation.y) < 1e-6) {
         Point direction = (targetPoint - agent.pos).Normalized();

--- a/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
+++ b/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
@@ -29,7 +29,7 @@ class GeneralizedCentrifugalForceModel:
     max_geometry_interaction_distance: float = 2
     max_neighbor_interpolation_distance: float = 0.1
     max_geometry_interpolation_distance: float = 0.1
-    max_neighbor_repulsion_force: float = 9
+    max_neighbor_repulsion_force: float = 30
     max_geometry_repulsion_force: float = 3
 
 

--- a/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
+++ b/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
@@ -29,7 +29,7 @@ class GeneralizedCentrifugalForceModel:
     max_geometry_interaction_distance: float = 2
     max_neighbor_interpolation_distance: float = 0.1
     max_geometry_interpolation_distance: float = 0.1
-    max_neighbor_repulsion_force: float = 30
+    max_neighbor_repulsion_force: float = 9
     max_geometry_repulsion_force: float = 3
 
 

--- a/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
+++ b/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
@@ -75,7 +75,7 @@ class GeneralizedCentrifugalForceModelAgentParameters:
     speed: float = 0.0
     e0: tuple[float, float] = (0.0, 0.0)
     position: tuple[float, float] = (0.0, 0.0)
-    orientation: tuple[float, float] = (0.0, 0.0)
+    orientation: tuple[float, float] = (1.0, 0.0)
     journey_id: int = -1
     stage_id: int = -1
     mass: float = 1

--- a/systemtest/test_model_properties.py
+++ b/systemtest/test_model_properties.py
@@ -142,7 +142,7 @@ def test_set_model_parameters_generalized_centrifugal_force_model(
     )
 
     agent_id = sim.add_agent(agent)
-    agent_id2 = sim.add_agent(agent2)
+    sim.add_agent(agent2)
 
     sim.agent(agent_id).model.speed = 2.0
     assert sim.agent(agent_id).model.speed == 2.0

--- a/systemtest/test_model_properties.py
+++ b/systemtest/test_model_properties.py
@@ -135,7 +135,14 @@ def test_set_model_parameters_generalized_centrifugal_force_model(
         stage_id=wp,
         position=(1, 1),
     )
+    agent2 = jps.GeneralizedCentrifugalForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(3, 1),
+    )
+
     agent_id = sim.add_agent(agent)
+    agent_id2 = sim.add_agent(agent2)
 
     sim.agent(agent_id).model.speed = 2.0
     assert sim.agent(agent_id).model.speed == 2.0


### PR DESCRIPTION
I found a bug in the calculation of the ellipse distances. 
Since orientation is a unit vector, it directly provides the cosine and sine of the rotation angle.
However, at first the orientation might be a zero vector.


In this PR, I will check all equations related to ellipses and update their documentation. 

Hopefully, by then we will have a correctly  performing  gcfm.