### PR TITLE
﻿﻿Improve DXF parsing robustness and debugging Information

### DIFF
--- a/scripts/parse_dxf.py
+++ b/scripts/parse_dxf.py
@@ -630,6 +630,11 @@ def plot_geometry(geometry_collection):
     for a in area.geoms:
         x, y = a.exterior.xy
         plt.fill(x, y, alpha=0.1, color="gray")
+        for hole in a.interiors:
+            hx, hy = hole.xy
+            ax.fill(
+                hx, hy, alpha=1, edgecolor="gray", facecolor="white", lw=0.3
+            )
 
     for e in exits.geoms:
         x, y = e.exterior.xy

--- a/scripts/parse_dxf.py
+++ b/scripts/parse_dxf.py
@@ -144,7 +144,14 @@ def parse_dxf_file(
         raise IncorrectDXFFileError(
             f"Layer '{outer_line_layer}' not found in DXF file.\n Available layers are: {layers_in_dxf}"
         )
-
+    missing_hole_layers = [
+        layer for layer in hole_layers if not layer_exists(layer, layers_in_dxf)
+    ]
+    if missing_hole_layers:
+        logging.warning(
+            f"Warning: These hole layers were not found in the DXF file: {missing_hole_layers}.\n"
+            f"Available layers: {layers_in_dxf}"
+        )
     # Iterate over all entities in the model
     for entity in msp:
         if entity.dxftype() == "LWPOLYLINE":

--- a/scripts/parse_dxf.py
+++ b/scripts/parse_dxf.py
@@ -93,11 +93,13 @@ def polyline_to_polygon(polyline):
 
     if len(points) < 3:
         logging.error(
-            "a polyline has at most 2 points and can not be a Polygon"
+            "A polyline with fewer than 3 points cannot form a valid polygon."
         )
         raise IncorrectDXFFileError(
-            "a polyline could not be converted to a Polygon", [points]
+            "Polyline conversion to a Polygon failed due to insufficient points.",
+            [points],
         )
+
     return Polygon(points)
 
 
@@ -364,12 +366,11 @@ def parse_dxf_file(
             else other_holes.append(hole)
         )
 
-    if len(other_holes) > 0:
+    if other_holes:
         logging.error(
-            f"{len(other_holes)} not simple polygons were parsed. These are "
-            f"not supported."
+            f"Detected {len(other_holes)} non-simple polygons in the hole layer. "
+            f"These polygons are not supported."
         )
-
         raise IncorrectDXFFileError(
             "The file contained at least one not simple hole polygon.",
             other_holes,
@@ -388,10 +389,10 @@ def parse_dxf_file(
             else other_exits.append(_exit)
         )
 
-    if len(other_exits) > 0:
+    if other_exits:
         logging.error(
-            f"{len(other_exits)} not simple polygons were parsed. These are "
-            f"not supported."
+            f"Detected {len(other_exits)} non-simple polygons in the exit layer(s). "
+            f"These polygons are not supported."
         )
         raise IncorrectDXFFileError(
             "The file contained at least one not simple exit polygon.",
@@ -411,10 +412,10 @@ def parse_dxf_file(
             else other_distributions.append(distribution)
         )
 
-    if len(other_distributions) > 0:
+    if other_distributions:
         logging.error(
-            f"{len(other_distributions)} not simple polygons were parsed. These are "
-            f"not supported."
+            f"Detected {len(other_distributions)} non-simple polygons in the distribution layer(s). "
+            f"These polygons are not supported."
         )
         raise IncorrectDXFFileError(
             "The file contained at least one not simple distribution polygon.",

--- a/scripts/parse_dxf.py
+++ b/scripts/parse_dxf.py
@@ -160,12 +160,16 @@ def parse_dxf_file(
                 or outer_line_layer in entity.dxf.layer
             ):
                 logging.error(
-                    f"There is a Polygon in layer {entity.dxf.layer} "
+                    f"There is a Polygon in layer <{entity.dxf.layer}> "
                     f"that is not closed. This may cause issues "
                     f"creating the polygon."
                 )
+                points = [(p[0], p[1]) for p in entity.get_points()]
+                shape = LineString(points)
+                logging.error("Shapely representation:", shape)
+                logging.error("-" * 50)
                 raise IncorrectDXFFileError(
-                    f"Unclosed polyline in layer {entity.dxf.layer}"
+                    f"Unclosed polyline in layer <{entity.dxf.layer}>"
                 )
             if any(
                 hole_layer in entity.dxf.layer for hole_layer in hole_layers

--- a/scripts/parse_dxf.py
+++ b/scripts/parse_dxf.py
@@ -11,7 +11,6 @@ import matplotlib.patches as mpatches
 import matplotlib.pyplot
 import matplotlib.pyplot as plt
 import shapely
-from shapely.ops import unary_union
 from shapely import (
     GeometryCollection,
     LineString,
@@ -21,6 +20,7 @@ from shapely import (
     polygonize,
     to_wkt,
 )
+from shapely.ops import unary_union
 
 logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
 

--- a/scripts/parse_dxf.py
+++ b/scripts/parse_dxf.py
@@ -142,7 +142,7 @@ def parse_dxf_file(
     logging.info(f"{outer_line_layer = }")
     if not layer_exists(outer_line_layer, layers_in_dxf):
         raise IncorrectDXFFileError(
-            f"Layer '{outer_line_layer}' not found in DXF file."
+            f"Layer '{outer_line_layer}' not found in DXF file.\n Available layers are: {layers_in_dxf}"
         )
 
     # Iterate over all entities in the model


### PR DESCRIPTION
This update fixes several problems in the script used to convert DXF files to WKT format. It also provides more detailed error messages to help users fix problems. 

- The script now provides clear error messages when parsing fails, guiding users to fix their DXF files. 
- Correctly handles sublayers (e.g., "0 ... walls" now matches "walls").
- Parse distributions and exits