### PR TITLE
Add missing properties to models

### DIFF
--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed.py
@@ -98,6 +98,16 @@ class CollisionFreeSpeedModelAgentParameters:
         self.journey_id = journey_id
         self.stage_id = stage_id
 
+    @property
+    @deprecated("deprecated, use 'desired_speed' instead.")
+    def v0(self) -> float:
+        return self.desired_speed
+
+    @v0.setter
+    @deprecated("deprecated, use 'desired_speed' instead.")
+    def v0(self, v0):
+        self.desired_speed = v0
+
     def as_native(self) -> py_jps.CollisionFreeSpeedModelAgentParameters:
         return py_jps.CollisionFreeSpeedModelAgentParameters(
             position=self.position,

--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed_v2.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed_v2.py
@@ -108,6 +108,16 @@ class CollisionFreeSpeedModelV2AgentParameters:
         self.strength_geometry_repulsion = strength_geometry_repulsion
         self.range_geometry_repulsion = range_geometry_repulsion
 
+    @property
+    @deprecated("deprecated, use 'desired_speed' instead.")
+    def v0(self) -> float:
+        return self.desired_speed
+
+    @v0.setter
+    @deprecated("deprecated, use 'desired_speed' instead.")
+    def v0(self, v0):
+        self.desired_speed = v0
+
     def as_native(
         self,
     ) -> py_jps.CollisionFreeSpeedModelV2AgentParameters:

--- a/python_modules/jupedsim/jupedsim/models/social_force.py
+++ b/python_modules/jupedsim/jupedsim/models/social_force.py
@@ -38,6 +38,8 @@ class SocialForceModel:
         """
         Init dataclass SocialForceMode to handle deprecated arguments.
         """
+        self.body_force = body_force
+
         if bodyForce is not None:
             warnings.warn(
                 "'bodyForce' is deprecated, use 'body_force' instead.",
@@ -45,8 +47,17 @@ class SocialForceModel:
                 stacklevel=2,
             )
             self.body_force = bodyForce
-        self.body_force = body_force
         self.friction = friction
+
+    @property
+    @deprecated("deprecated, use 'body_force' instead.")
+    def bodyForce(self) -> float:
+        return self.body_force
+
+    @bodyForce.setter
+    @deprecated("deprecated, use 'body_force' instead.")
+    def bodyForce(self, bodyForce):
+        self.body_force = bodyForce
 
 
 @dataclass(kw_only=True)
@@ -138,6 +149,56 @@ class SocialForceModelAgentParameters:
             else:
                 setattr(self, new_name, locals()[new_name])
         print(self)
+
+    @property
+    @deprecated("deprecated, use 'desired_speed' instead.")
+    def desiredSpeed(self) -> float:
+        return self.desired_speed
+
+    @desiredSpeed.setter
+    @deprecated("deprecated, use 'desired_speed' instead.")
+    def desiredSpeed(self, desiredSpeed):
+        self.desired_speed = desiredSpeed
+
+    @property
+    @deprecated("deprecated, use 'reaction_time' instead.")
+    def reactionTime(self) -> float:
+        return self.reaction_time
+
+    @reactionTime.setter
+    @deprecated("deprecated, use 'reaction_time' instead.")
+    def reactionTime(self, reactionTime):
+        self.reaction_time = reactionTime
+
+    @property
+    @deprecated("deprecated, use 'agent_scale' instead.")
+    def agentScale(self) -> float:
+        return self.agent_scale
+
+    @agentScale.setter
+    @deprecated("deprecated, use 'agent_scale' instead.")
+    def agentScale(self, agentScale):
+        self.agent_scale = agentScale
+
+    @property
+    @deprecated("deprecated, use 'obstacle_scale' instead.")
+    def obstacleScale(self) -> float:
+        return self.obstacle_scale
+
+    @obstacleScale.setter
+    @deprecated("deprecated, use 'obstacle_scale' instead.")
+    def obstacleScale(self, obstacleScale):
+        self.obstacle_scale = obstacleScale
+
+    @property
+    @deprecated("deprecated, use 'force_distance' instead.")
+    def forceDistance(self) -> float:
+        return self.force_distance
+
+    @forceDistance.setter
+    @deprecated("deprecated, use 'force_distance' instead.")
+    def forceDistance(self, forceDistance):
+        self.force_distance = forceDistance
 
     def as_native(
         self,

--- a/systemtest/test_model_properties.py
+++ b/systemtest/test_model_properties.py
@@ -257,6 +257,47 @@ def test_set_model_parameters_collision_free_speed_model(
     assert sim.agent(agent_id).model.radius == 4.0
 
 
+def test_collision_free_speed_model_agent_paramters_v0_setter_deprecated(
+    simulation_with_collision_free_speed_model,
+):
+    sim = simulation_with_collision_free_speed_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.CollisionFreeSpeedModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    with pytest.warns(
+        DeprecationWarning, match="deprecated, use 'desired_speed' instead"
+    ):
+        agent.v0 = 3
+        assert agent.desired_speed == 3
+
+
+def test_collision_free_speed_model_agent_paramters_v0_getter_deprecated(
+    simulation_with_collision_free_speed_model,
+):
+    sim = simulation_with_collision_free_speed_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.CollisionFreeSpeedModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    desired_speed = agent.desired_speed
+    with pytest.warns(
+        DeprecationWarning,
+        match="deprecated, use 'desired_speed' instead",
+    ):
+        assert agent.v0 == desired_speed
+
+
 @pytest.fixture
 def simulation_with_generalized_centrifugal_force_model():
     return jps.Simulation(

--- a/systemtest/test_model_properties.py
+++ b/systemtest/test_model_properties.py
@@ -403,7 +403,7 @@ def test_desired_speed_deprecated(simulation_with_social_force_model):
     journey_id = sim.add_journey(jps.JourneyDescription([wp]))
 
     agent = jps.SocialForceModelAgentParameters(
-        journey_id=journey_id, stage_id=wp, position=(1, 1), desiredSpeed=1.1
+        journey_id=journey_id, stage_id=wp, position=(1, 1), desired_speed=1.1
     )
     agent_id = sim.add_agent(agent)
 
@@ -424,7 +424,7 @@ def test_reaction_time_deprecated(simulation_with_social_force_model):
     journey_id = sim.add_journey(jps.JourneyDescription([wp]))
 
     agent = jps.SocialForceModelAgentParameters(
-        journey_id=journey_id, stage_id=wp, position=(1, 1), reactionTime=1.1
+        journey_id=journey_id, stage_id=wp, position=(1, 1), reaction_time=1.1
     )
     agent_id = sim.add_agent(agent)
 
@@ -446,7 +446,7 @@ def test_agent_scale_deprecated(simulation_with_social_force_model):
         journey_id=journey_id,
         stage_id=wp,
         position=(1, 1),
-        agentScale=1.1,
+        agent_scale=1.1,
     )
     agent_id = sim.add_agent(agent)
 
@@ -465,7 +465,7 @@ def test_obstacle_scale_deprecated(simulation_with_social_force_model):
     journey_id = sim.add_journey(jps.JourneyDescription([wp]))
 
     agent = jps.SocialForceModelAgentParameters(
-        journey_id=journey_id, stage_id=wp, position=(1, 1), obstacleScale=1.1
+        journey_id=journey_id, stage_id=wp, position=(1, 1), obstacle_scale=1.1
     )
     agent_id = sim.add_agent(agent)
 
@@ -484,7 +484,7 @@ def test_force_distance_deprecated(simulation_with_social_force_model):
     journey_id = sim.add_journey(jps.JourneyDescription([wp]))
 
     agent = jps.SocialForceModelAgentParameters(
-        journey_id=journey_id, stage_id=wp, position=(1, 1), forceDistance=1.1
+        journey_id=journey_id, stage_id=wp, position=(1, 1), force_distance=1.1
     )
     agent_id = sim.add_agent(agent)
 

--- a/systemtest/test_model_properties.py
+++ b/systemtest/test_model_properties.py
@@ -131,6 +131,47 @@ def test_set_model_parameters_collision_free_speed_model_v2(
     assert sim.agent(agent_id).model.range_geometry_repulsion == 8.0
 
 
+def test_collision_free_speed_model_v2_agent_paramters_v0_setter_deprecated(
+    simulation_with_collision_free_speed_model_v2,
+):
+    sim = simulation_with_collision_free_speed_model_v2
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.CollisionFreeSpeedModelV2AgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    with pytest.warns(
+        DeprecationWarning, match="deprecated, use 'desired_speed' instead"
+    ):
+        agent.v0 = 3
+        assert agent.desired_speed == 3
+
+
+def test_collision_free_speed_model_v2_agent_paramters_v0_getter_deprecated(
+    simulation_with_collision_free_speed_model_v2,
+):
+    sim = simulation_with_collision_free_speed_model_v2
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.CollisionFreeSpeedModelV2AgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    desired_speed = agent.desired_speed
+    with pytest.warns(
+        DeprecationWarning,
+        match="deprecated, use 'desired_speed' instead",
+    ):
+        assert agent.v0 == desired_speed
+
+
 @pytest.fixture
 def simulation_with_anticipation_velocity_model():
     return jps.Simulation(

--- a/systemtest/test_model_properties.py
+++ b/systemtest/test_model_properties.py
@@ -366,6 +366,25 @@ def simulation_with_social_force_model_body_force():
         )
 
 
+def test_social_force_model_body_force_setter_deprecated():
+    model = jps.SocialForceModel()
+    with pytest.warns(
+        DeprecationWarning, match="deprecated, use 'body_force' instead"
+    ):
+        model.bodyForce = 5
+        assert model.body_force == 5
+
+
+def test_social_force_model_body_force_getter_deprecated():
+    model = jps.SocialForceModel()
+    model.body_force = 5
+
+    with pytest.warns(
+        DeprecationWarning, match="deprecated, use 'body_force' instead"
+    ):
+        assert model.bodyForce == 5
+
+
 def test_body_force_deprecated(simulation_with_social_force_model_body_force):
     assert simulation_with_social_force_model_body_force is not None
 
@@ -516,3 +535,208 @@ def test_set_model_parameters_social_force_model(
 
     sim.agent(agent_id).model.radius = 9.0
     assert sim.agent(agent_id).model.radius == 9.0
+
+
+def test_social_force_model_agent_paramters_desired_speed_setter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    with pytest.warns(
+        DeprecationWarning, match="deprecated, use 'desired_speed' instead"
+    ):
+        agent.desiredSpeed = 3
+        assert agent.desired_speed == 3
+
+
+def test_social_force_model_agent_paramters_desired_speed_getter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    desired_speed = agent.desired_speed
+    with pytest.warns(
+        DeprecationWarning,
+        match="deprecated, use 'desired_speed' instead",
+    ):
+        assert agent.desiredSpeed == desired_speed
+
+
+def test_social_force_model_agent_paramters_reaction_time_setter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    with pytest.warns(
+        DeprecationWarning, match="deprecated, use 'reaction_time' instead"
+    ):
+        agent.reactionTime = 3
+        assert agent.reaction_time == 3
+
+
+def test_social_force_model_agent_paramters_reaction_time_getter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    reaction_time = agent.reaction_time
+    with pytest.warns(
+        DeprecationWarning,
+        match="deprecated, use 'reaction_time' instead",
+    ):
+        assert agent.reactionTime == reaction_time
+
+
+def test_social_force_model_agent_paramters_agent_scale_setter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    with pytest.warns(
+        DeprecationWarning, match="deprecated, use 'agent_scale' instead"
+    ):
+        agent.agentScale = 3
+        assert agent.agent_scale == 3
+
+
+def test_social_force_model_agent_paramters_agent_scale_getter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    agent_scale = agent.agent_scale
+    with pytest.warns(
+        DeprecationWarning,
+        match="deprecated, use 'agent_scale' instead",
+    ):
+        assert agent.agentScale == agent_scale
+
+
+def test_social_force_model_agent_paramters_obstacle_scale_setter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    with pytest.warns(
+        DeprecationWarning, match="deprecated, use 'obstacle_scale' instead"
+    ):
+        agent.obstacleScale = 3
+        assert agent.obstacle_scale == 3
+
+
+def test_social_force_model_agent_paramters_obstacle_scale_getter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    obstacle_scale = agent.obstacle_scale
+    with pytest.warns(
+        DeprecationWarning,
+        match="deprecated, use 'obstacle_scale' instead",
+    ):
+        assert agent.obstacleScale == obstacle_scale
+
+
+def test_social_force_model_agent_paramters_force_distance_setter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    with pytest.warns(
+        DeprecationWarning, match="deprecated, use 'force_distance' instead"
+    ):
+        agent.forceDistance = 3
+        assert agent.force_distance == 3
+
+
+def test_social_force_model_agent_paramters_force_distance_getter_deprecated(
+    simulation_with_social_force_model,
+):
+    sim = simulation_with_social_force_model
+    wp = sim.add_waypoint_stage((10, 1), 0.5)
+    journey_id = sim.add_journey(jps.JourneyDescription([wp]))
+
+    agent = jps.SocialForceModelAgentParameters(
+        journey_id=journey_id,
+        stage_id=wp,
+        position=(1, 1),
+    )
+
+    force_distance = agent.force_distance
+    with pytest.warns(
+        DeprecationWarning,
+        match="deprecated, use 'force_distance' instead",
+    ):
+        assert agent.forceDistance == force_distance


### PR DESCRIPTION
Due to the renaming in #1440 the renamed properties were no longer available as properties, breaking backward compatibility. This would mean a break in the API. With this PR these depreacted properties are again available, each emitting a depreaction warning upon usage.