### PR TITLE
Add configurable SQLite write mode with fast default

### DIFF
--- a/python_modules/jupedsim/jupedsim/sqlite_serialization.py
+++ b/python_modules/jupedsim/jupedsim/sqlite_serialization.py
@@ -57,8 +57,6 @@ class SqliteTrajectoryWriter(TrajectoryWriter):
         self._con.execute("PRAGMA synchronous=OFF;")
         # Don't allow rollbacks (we don't have need for it)
         self._con.execute("PRAGMA journal_mode=OFF;")
-        # Lock the DB exclusively
-        self._con.execute("PRAGMA locking_mode=EXCLUSIVE;")
 
     def begin_writing(self, simulation: Simulation) -> None:
         """Begin writing trajectory data.


### PR DESCRIPTION
Introduces a `fast_writes` parameter to SqliteTrajectoryWriter.

Default: synchronous=OFF for maximum performance.

Optional safer mode: journal_mode=WAL, synchronous=NORMAL.

This makes SQLite write behavior explicit and configurable (and fast).