### PR TITLE
Add dependabot config for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
Tested in fork, this opened this PR for updating the dependencies on a monthly basis: https://github.com/schroedtert/jupedsim/pull/2

When merged the dependabot needs to be enabled in the settings