### PR TITLE
Issue #1536: Notebook animations were not shown in documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ deprecated~=1.2.18
 
 # notebook dependencies
 shapely
-plotly<6
+plotly>=6
 plotly-express
 numpy
 pandas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ deprecated~=1.2.18
 
 # notebook dependencies
 shapely
-plotly
+plotly<6
 plotly-express
 numpy
 pandas

--- a/python_modules/jupedsim/jupedsim/internal/notebook_utils.py
+++ b/python_modules/jupedsim/jupedsim/internal/notebook_utils.py
@@ -14,6 +14,10 @@ import numpy as np
 import pandas as pd
 import pedpy
 import plotly.graph_objects as go
+import plotly.io as pio
+
+# Fix for plotly 6.x wrt animations in jupyter notebooks
+pio.renderers.default = "sphinx_gallery"
 
 DUMMY_SPEED = -1000
 


### PR DESCRIPTION
Fix for #1536:
- Plotly 6 breaks rendering the notebook animations in documentation.
- Fix is to downgrade to plotly<6 for the time being. We probably want to revisit this at some point in the future.