### PR TITLE
Fixed #1572: Install missing warp_driver_model.h with cmake --install.

### DIFF
--- a/libjupedsim/CMakeLists.txt
+++ b/libjupedsim/CMakeLists.txt
@@ -131,6 +131,7 @@ install(
         ${header_dest}/stage.h
         ${header_dest}/transition.h
         ${header_dest}/types.h
+        ${header_dest}/warp_driver_model.h
     DESTINATION ${header_dest}
 )
 


### PR DESCRIPTION
warp_driver_model.h is not installed via "cmake --install". This is purely an issue when using JuPedSim via C-API and does not affect the Python module at all.

Related issue: https://github.com/PedestrianDynamics/jupedsim/issues/1572