### PR TITLE
Fixes 1575: Index out of bounds issue in RoutingEngine

### DIFF
--- a/libsimulator/src/RoutingEngine.cpp
+++ b/libsimulator/src/RoutingEngine.cpp
@@ -301,11 +301,9 @@ RoutingEngine::straightenPath(Point from, Point to, const std::vector<CDT::Face_
     // This is an over estimation but IMO preferable to repeadted allocations.
     // Ideally we replace this with something w.o. allocations
     waypoints.reserve(path.size() + 1);
-    for(size_t index_portal = 1; index_portal <= portalCount; ++index_portal) {
+    for(size_t index_portal = 1; index_portal < portalCount; ++index_portal) {
         const auto face_from = path[index_portal - 1];
         const auto face_to = path[index_portal];
-        if(face_from->neighbor(0) == face_to) {
-        }
 
         const auto portal =
             index_portal < portalCount ? get_edge(face_from, face_to) : LineSegment(to, to);

--- a/libsimulator/src/RoutingEngine.cpp
+++ b/libsimulator/src/RoutingEngine.cpp
@@ -301,12 +301,11 @@ RoutingEngine::straightenPath(Point from, Point to, const std::vector<CDT::Face_
     // This is an over estimation but IMO preferable to repeadted allocations.
     // Ideally we replace this with something w.o. allocations
     waypoints.reserve(path.size() + 1);
-    for(size_t index_portal = 1; index_portal < portalCount; ++index_portal) {
+    for(size_t index_portal = 1; index_portal <= portalCount; ++index_portal) {
         const auto face_from = path[index_portal - 1];
-        const auto face_to = path[index_portal];
 
         const auto portal =
-            index_portal < portalCount ? get_edge(face_from, face_to) : LineSegment(to, to);
+            index_portal < portalCount ? get_edge(face_from, path[index_portal]) : LineSegment(to, to);
 
         const auto line_segment_left = portal.p2;
         const auto line_segment_right = portal.p1;

--- a/libsimulator/src/RoutingEngine.cpp
+++ b/libsimulator/src/RoutingEngine.cpp
@@ -304,8 +304,8 @@ RoutingEngine::straightenPath(Point from, Point to, const std::vector<CDT::Face_
     for(size_t index_portal = 1; index_portal <= portalCount; ++index_portal) {
         const auto face_from = path[index_portal - 1];
 
-        const auto portal =
-            index_portal < portalCount ? get_edge(face_from, path[index_portal]) : LineSegment(to, to);
+        const auto portal = index_portal < portalCount ? get_edge(face_from, path[index_portal]) :
+                                                         LineSegment(to, to);
 
         const auto line_segment_left = portal.p2;
         const auto line_segment_right = portal.p1;


### PR DESCRIPTION
In RoutingEngine:
- straightenPath runs a for-loop from 1 to size of the path vector (including that item) and accesses each element. This obviously accesses an item outside the defined vector.
- There is some dead code directly afterwards which compares `face_from->neighbor(0) == face_to` but does nothing in the body. Just checking neighbor 0 looks incomplete as well. The code should be removed.

This addresses #1575.