### PR TITLE
add Python tests, and partially fix them

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -295,6 +295,12 @@ jobs:
       - name: Check installation
         run: |
           python -c "import jupedsim; print(jupedsim.__version__)"
+      - name: Test jupedsim Python modules
+        run: |
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+          # Run only the jupedsim Python tests from the installed wheel
+          python -m pytest -q python_modules/jupedsim/tests
+          python -m pytest -q systemtest
   test-sdist:
     name: Test sdist install
     needs: [ build_sdist ]

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -296,7 +296,9 @@ jobs:
         run: |
           python -c "import jupedsim; print(jupedsim.__version__)"
       - name: Test jupedsim Python modules
+        shell: bash
         run: |
+          ls
           if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
           # Run only the jupedsim Python tests from the installed wheel
           python -m pytest -q python_modules/jupedsim/tests
@@ -324,11 +326,13 @@ jobs:
         run: |
           python -c "import jupedsim; print(jupedsim.__version__)"
       - name: Install test dependencies
+        shell: bash
         run: |
+          ls
           python -m pip install -U pip
-          # Install project test dependencies so pytest and any test helpers are available
           if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
       - name: Run pytest against installed wheel
+        shell: bash
         run: |
           # Run only the jupedsim Python tests from the installed wheel
           python -m pytest -q python_modules/jupedsim/tests

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -2,7 +2,7 @@ name: Build CI wheels
 on:
   schedule:
     # Runs at 02:00 a.m. each Sunday
-    - cron: '00 2 * * 0'
+    - cron: "00 2 * * 0"
   push:
     branches:
       - master
@@ -12,7 +12,7 @@ on:
       - master
       - rls-*
   release:
-    types: [published]
+    types: [ published ]
     branches:
       - master
       - rls-*
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [{cc: clang, cxx: clang++}, {cc: gcc, cxx: g++}]
+        toolchain: [ { cc: clang, cxx: clang++ }, { cc: gcc, cxx: g++ } ]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -245,14 +245,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - name: Build wheels for CPython ${{ matrix.cibw_build }} on ${{ matrix.cibw_archs }}
+      - name: Build wheels for CPython ${{ matrix.cibw_build }} on ${{ matrix.cibw_archs
+          }}
         uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
       - name: Extract Python Version (Unix/Mac)
         shell: bash
-        run: echo "PYTHON_VERSION=$(echo ${{ matrix.cibw_build }} | cut -d'-' -f1)" >> $GITHUB_ENV
+        run: echo "PYTHON_VERSION=$(echo ${{ matrix.cibw_build }} | cut -d'-' -f1)" >>
+          $GITHUB_ENV
         if: runner.os != 'Windows'
       - name: Extract Python Version (Windows)
         if: runner.os == 'Windows'
@@ -263,17 +265,18 @@ jobs:
           echo "PYTHON_VERSION=$pythonVersion" | Out-File -Append -FilePath $env:GITHUB_ENV
       - uses: actions/upload-artifact@v7
         with:
-          name: python-packages-${{ matrix.os }}-${{ matrix.cibw_archs }}-${{ env.PYTHON_VERSION }}
+          name: python-packages-${{ matrix.os }}-${{ matrix.cibw_archs }}-${{
+            env.PYTHON_VERSION }}
           path: ./wheelhouse/*.whl
           if-no-files-found: error
   test-wheels:
     name: Test wheel on ${{ matrix.os }} with Python ${{ matrix.python-version }}
-    needs: [build_wheels]
+    needs: [ build_wheels ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14, macos-15, macos-26]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ ubuntu-latest, windows-latest, macos-14, macos-15, macos-26 ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -294,7 +297,7 @@ jobs:
           python -c "import jupedsim; print(jupedsim.__version__)"
   test-sdist:
     name: Test sdist install
-    needs: [build_sdist]
+    needs: [ build_sdist ]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.13
@@ -314,8 +317,18 @@ jobs:
       - name: Check installation
         run: |
           python -c "import jupedsim; print(jupedsim.__version__)"
+      - name: Install test dependencies
+        run: |
+          python -m pip install -U pip
+          # Install project test dependencies so pytest and any test helpers are available
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+      - name: Run pytest against installed wheel
+        run: |
+          # Run only the jupedsim Python tests from the installed wheel
+          python -m pytest -q python_modules/jupedsim/tests
+          python -m pytest -q systemtest
   pypi-publish:
-    needs: [test-wheels, test-sdist]
+    needs: [ test-wheels, test-sdist ]
     if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
     name: Publish to PyPI
     runs-on: ubuntu-latest

--- a/python_modules/jupedsim/tests/test_build_geometry.py
+++ b/python_modules/jupedsim/tests/test_build_geometry.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import pytest
 import shapely
-from jupedsim.util import GeometryError, _polygons_from_geometry_collection
+from jupedsim.geometry_utils import (
+    GeometryError,
+    _polygons_from_geometry_collection,
+)
 
 
 @pytest.mark.parametrize(

--- a/python_modules/jupedsim/tests/test_distributions.py
+++ b/python_modules/jupedsim/tests/test_distributions.py
@@ -88,13 +88,13 @@ def test_bounding_box_determination():
         (1, 4),
         (3, 2),
     ]
-    s_polygon = distributions.shply.Polygon(polygon)
+    s_polygon = distributions.shapely.Polygon(polygon)
     expected_box = [(0, 0), (12, 10.5)]
     assert distributions.__get_bounding_box(s_polygon) == expected_box
 
 
 def test_minimal_distance_to_polygon():
-    polygon = distributions.shply.Polygon(
+    polygon = distributions.shapely.Polygon(
         [(0, 0), (4, 1), (5, 3), (4, 5), (2, 5), (0, 3)]
     )
     pt = (3, 3)
@@ -116,7 +116,7 @@ def test_minimal_distance_to_polygon():
 
 def test_seed_works_correct_for_determination_by_number():
     polygon = [(0, 0), (10, 0), (10, 10), (0, 10)]
-    polygon = distributions.shply.Polygon(polygon)
+    polygon = distributions.shapely.Polygon(polygon)
     distance_to_agents, distance_to_polygon = 0.3, 0.3
     number_of_agents = 100
     set_seed = 1337
@@ -139,7 +139,7 @@ def test_seed_works_correct_for_determination_by_number():
 
 def test_seed_works_correct_for_determination_in_circles_by_number():
     polygon = [(0, 0), (10, 0), (10, 10), (0, 10)]
-    polygon = distributions.shply.Polygon(polygon)
+    polygon = distributions.shapely.Polygon(polygon)
     number_of_agents = [75]
     distance_to_agents = 0.3
     distance_to_polygon = 0.3
@@ -188,7 +188,7 @@ def test_determination_by_number_creates_correct_points():
         [(8.5, 4), (10, 3), (12, 6.5), (10, 7)],
         [(10, 10.5), (11, 9.5), (14, 12.5), (11, 13)],
     ]
-    polygon = distributions.shply.Polygon(polygon, holes)
+    polygon = distributions.shapely.Polygon(polygon, holes)
     distance_to_agents, distance_to_polygon = 0.3, 0.3
     number_of_agents = 450
     set_seed = 1337
@@ -204,7 +204,7 @@ def test_determination_by_number_creates_correct_points():
 
     # all created points contained inside polygon
     for sample in samples:
-        assert polygon.contains(distributions.shply.Point(sample))
+        assert polygon.contains(distributions.shapely.Point(sample))
 
     # all Points have enough distance to another
     for i, sample in enumerate(samples):
@@ -223,7 +223,7 @@ def test_determination_by_number_creates_correct_points():
 def test_determination_by_density_creates_correct_amount():
     polygon = [(0, 0), (10, 0), (10, 10), (0, 10)]
     # polygon 10 x 10 square with 100m²
-    polygon = distributions.shply.Polygon(polygon)
+    polygon = distributions.shapely.Polygon(polygon)
     distance_to_agents, distance_to_polygon = 0.3, 0.3
     density = 2.5
     # 2.5 persons per m²
@@ -257,7 +257,7 @@ def test_distribution_in_circle_by_number_creates_correct_points():
         [(8.5, 4), (10, 3), (12, 6.5), (10, 7)],
         [(10, 10.5), (11, 9.5), (14, 12.5), (11, 13)],
     ]
-    polygon = distributions.shply.Polygon(polygon, holes)
+    polygon = distributions.shapely.Polygon(polygon, holes)
     number_of_agents = [200, 150]
     distance_to_agents = 0.3
     distance_to_polygon = 0.3
@@ -299,7 +299,7 @@ def test_distribution_in_circle_by_number_creates_correct_points():
 
     # all created points contained inside polygon
     for sample in samples:
-        assert polygon.contains(distributions.shply.Point(sample))
+        assert polygon.contains(distributions.shapely.Point(sample))
 
     # all Points have enough distance to another
     for i, sample in enumerate(samples):
@@ -318,7 +318,7 @@ def test_distribution_in_circle_by_number_creates_correct_points():
 def test_distribution_in_circle_by_density_creates_correct_amount():
     polygon = [(0, 0), (10, 0), (10, 10), (0, 10)]
     # polygon 10 x 10 square with 100m²
-    polygon = distributions.shply.Polygon(polygon)
+    polygon = distributions.shapely.Polygon(polygon)
     densities = [1]
     distance_to_agents = 0.3
     distance_to_polygon = 0.3
@@ -343,7 +343,7 @@ def test_distribution_in_circle_by_density_creates_correct_amount():
 
 def test_seed_works_correct_for_distribution_till_full():
     polygon = [(0, 0), (10, 0), (10, 10), (0, 10)]
-    polygon = distributions.shply.Polygon(polygon)
+    polygon = distributions.shapely.Polygon(polygon)
     distance_to_agents, distance_to_polygon = 0.75, 0.75
     set_seed = 1337
     samples1 = distributions.distribute_until_filled(
@@ -380,7 +380,7 @@ def test_distribution_by_percentage_creates_correct_points():
         [(8.5, 4), (10, 3), (12, 6.5), (10, 7)],
         [(10, 10.5), (11, 9.5), (14, 12.5), (11, 13)],
     ]
-    polygon = distributions.shply.Polygon(polygon, holes)
+    polygon = distributions.shapely.Polygon(polygon, holes)
     percent = 73
     distance_to_agents = 2.0
     distance_to_polygon = 1.0
@@ -398,7 +398,7 @@ def test_distribution_by_percentage_creates_correct_points():
 
     # all created points contained inside polygon
     for sample in samples:
-        assert polygon.contains(distributions.shply.Point(sample))
+        assert polygon.contains(distributions.shapely.Point(sample))
 
     # all Points have enough distance to another
     for i, sample in enumerate(samples):
@@ -416,7 +416,7 @@ def test_distribution_by_percentage_creates_correct_points():
 
 def test_seed_works_correct_for_distribution_by_percentage():
     polygon = [(0, 0), (10, 0), (10, 10), (0, 10)]
-    polygon = distributions.shply.Polygon(polygon)
+    polygon = distributions.shapely.Polygon(polygon)
     distance_to_agents, distance_to_polygon = 0.75, 0.75
     set_seed = 1337
     percent = 73
@@ -454,7 +454,7 @@ def test_box_of_intersection():
         (8, 10),
         (0, 10),
     ]
-    s_polygon = distributions.shply.Polygon(polygon)
+    s_polygon = distributions.shapely.Polygon(polygon)
     center_point = (4, 7)
     outer_radius = 3.5
     expected_box = [(0.5, 4), (7.35329, 10)]
@@ -484,7 +484,7 @@ def test_catch_wrong_inputs_for_wrong_polygon_type():
 
 
 def test_catch_wrong_inputs_negativ_value():
-    s_polygon = distributions.shply.Polygon(
+    s_polygon = distributions.shapely.Polygon(
         [(0, 0), (10, 0), (10, 10), (0, 10)]
     )
     center_point = (0, 0)
@@ -513,7 +513,7 @@ test_parameters = [
 def test_catch_wrong_inputs_incorrect_parameter(
     polygon, center_point, circle_segment_radii, numbers_of_agents
 ):
-    s_polygon = distributions.shply.Polygon(polygon)
+    s_polygon = distributions.shapely.Polygon(polygon)
     with pytest.raises(distributions.IncorrectParameterError):
         distributions.__catch_wrong_inputs(
             polygon=s_polygon,
@@ -542,7 +542,7 @@ test_parameters = [
 def test_catch_wrong_inputs_overlapping_circles(
     polygon, center_point, circle_segment_radii, numbers_of_agents
 ):
-    s_polygon = distributions.shply.Polygon(polygon)
+    s_polygon = distributions.shapely.Polygon(polygon)
     with pytest.raises(distributions.OverlappingCirclesError):
         distributions.__catch_wrong_inputs(
             polygon=s_polygon,
@@ -605,7 +605,7 @@ test_parameters = [
 def test_distribution_till_full_creates_correct_points(
     polygon, holes, distance_to_agents, distance_to_polygon, expected_size
 ):
-    polygon = distributions.shply.Polygon(polygon, holes)
+    polygon = distributions.shapely.Polygon(polygon, holes)
     set_seed = 1337
     samples = distributions.distribute_until_filled(
         polygon=polygon,
@@ -619,7 +619,7 @@ def test_distribution_till_full_creates_correct_points(
 
     # all created points contained inside polygon
     for sample in samples:
-        assert polygon.contains(distributions.shply.Point(sample))
+        assert polygon.contains(distributions.shapely.Point(sample))
 
     # all Points have enough distance to another
     for i, sample in enumerate(samples):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,9 @@ setuptools
 # test deps
 pytest~=8.3
 pandas~=2.2
+ezdf
+geopandas
+typer
 
 # ci deps
 jinja2~=3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ setuptools
 # test deps
 pytest~=8.3
 pandas~=2.2
-ezdf
+ezdxf
 geopandas
 typer
 


### PR DESCRIPTION
I run the python tests again, therefore I

- added jobs to the CI to use pytest to run `systemtest` and `jupedsim/tests`
- updated the requirements so tests can run
- changed minor details to make most tests pass again
 
Currently, one test is still failing. In an effort to catch implementation errors as early as possible these tests should be run and also extended. 

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1582/
<!-- PREVIEW-URL-END -->