### PR TITLE
Correct function argument for Timer context manager

### DIFF
--- a/python_modules/jupedsim/jupedsim/internal/tracing.py
+++ b/python_modules/jupedsim/jupedsim/internal/tracing.py
@@ -128,11 +128,11 @@ class Timer:
 
         @contextmanager
         def timer_region():
-            self.push_timer(name)
+            self.push_timer(func)
             try:
                 yield
             finally:
-                self.pop_timer(name)
+                self.pop_timer(func)
 
         return timer_region()
 


### PR DESCRIPTION
During the previous PR, I added context manager and decorators to the timer class. 
Unfortunately, I  missed changing back some parameters in the context manager function call.

I changed them accordingly, the unit test in place would have caught it.
We should move forward with #1583, so that the CI catches these silly mistakes in the future.


<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1584/
<!-- PREVIEW-URL-END -->