### PR TITLE
Fix another issue in A* with last triangle and add a test for it.

### DIFF
--- a/libsimulator/src/RoutingEngine.cpp
+++ b/libsimulator/src/RoutingEngine.cpp
@@ -130,19 +130,6 @@ std::vector<Point> RoutingEngine::ComputeAllWaypoints(Point currentPosition, Poi
         open_states.pop_back();
         closed_states.insert(std::make_pair(current_state->id, current_state));
 
-        if(current_state->id == to) {
-            // Unlike in A* this is only a first candidate solution
-            // Now compute the actual path length via funnel algorithm
-            // store path and length if this variant is the shortest found so far
-            const auto vertex_ids = current_state->path();
-            const auto found_path = straightenPath(currentPosition, destination, vertex_ids);
-            const double found_path_length = length_of_path(found_path);
-            if(found_path_length < path_length) {
-                path = found_path;
-                path_length = found_path_length;
-            }
-        }
-
         if(current_state->f_value() >= path_length) {
             // This search nodes f-value already excedes our paths length, and since the f-value is
             // underestimation of the path length the excat path cannot be shorter than what we have
@@ -211,7 +198,12 @@ std::vector<Point> RoutingEngine::ComputeAllWaypoints(Point currentPosition, Poi
             // (minimum-f_value) to arrive.  The closed_states guard would otherwise
             // block all subsequent routes from being evaluated.
             if(target == to) {
+                // g_value + h_value is f_value which is a lower bound and therefore needs
+                // to be smaller than current path length to be a good candidate.
                 if(g_value + h_value < path_length) {
+                    // Unlike in A* this is only a first candidate solution
+                    // Now compute the actual path length via funnel algorithm
+                    // store path and length if this variant is the shortest found so far
                     const SearchState dest_state{g_value, h_value, to, current_state.get()};
                     const auto vertex_ids = dest_state.path();
                     const auto found_path =

--- a/libsimulator/src/RoutingEngine.cpp
+++ b/libsimulator/src/RoutingEngine.cpp
@@ -206,6 +206,25 @@ std::vector<Point> RoutingEngine::ComputeAllWaypoints(Point currentPosition, Poi
 
             const double g_value = std::max(g_value_1, std::max(g_value_2, g_value_3));
 
+            // Evaluate every route that reaches the destination inline so that all
+            // candidate routes have their funnel computed — not just the first one
+            // (minimum-f_value) to arrive.  The closed_states guard would otherwise
+            // block all subsequent routes from being evaluated.
+            if(target == to) {
+                if(g_value + h_value < path_length) {
+                    const SearchState dest_state{g_value, h_value, to, current_state.get()};
+                    const auto vertex_ids = dest_state.path();
+                    const auto found_path =
+                        straightenPath(currentPosition, destination, vertex_ids);
+                    const double found_path_length = length_of_path(found_path);
+                    if(found_path_length < path_length) {
+                        path = found_path;
+                        path_length = found_path_length;
+                    }
+                }
+                continue;
+            }
+
             // NOTE(kkratz): Clang16 seems to be confused with capturing a structured binding
             // and emits a warnign when capturing 'target' directly As of C++20 this SHOULD(TM)
             // be valid code but see:

--- a/systemtest/test_routing.py
+++ b/systemtest/test_routing.py
@@ -59,6 +59,15 @@ BAD_ASTAR_ROUTINGS = [
         "max_diff": 0.2,
     },
     {
+        "test_name": "corner_with_shortcut2",
+        "description": "Same starting point, but end points differ just 0.03 on y axis, but total distance diff was >>0.03",
+        "wkt_path": "examples/geometry/corner_with_shortcut.wkt",
+        "error_type": "max_diff",
+        "path1": [(11.80, 1.00), (28.50, 13.54)],
+        "path2": [(11.80, 1.00), (28.50, 13.55)],
+        "max_diff": 0.01,
+    },
+    {
         "test_name": "aknz_evac",
         "description": "Direct path possible, but path was ways longer",
         "error_type": "direct path possible",
@@ -106,6 +115,9 @@ def test_max_diff_example(test_entry):
 
     distance1 = path_distance(path1)
     distance2 = path_distance(path2)
+    print(
+        f"distance1: {distance1}, distance2: {distance2}, max-diff: {test_entry['max_diff']}"
+    )
 
     distance_diff = math.fabs(distance2 - distance1)
     assert distance_diff <= test_entry["max_diff"]

--- a/systemtest/test_routing.py
+++ b/systemtest/test_routing.py
@@ -115,10 +115,6 @@ def test_max_diff_example(test_entry):
 
     distance1 = path_distance(path1)
     distance2 = path_distance(path2)
-    print(
-        f"distance1: {distance1}, distance2: {distance2}, max-diff: {test_entry['max_diff']}"
-    )
-
     distance_diff = math.fabs(distance2 - distance1)
     assert distance_diff <= test_entry["max_diff"]
 
@@ -137,7 +133,6 @@ def test_direct_path_possible_example(test_entry):
     navi = jps.RoutingEngine(geometry)
 
     path = navi.compute_waypoints(*test_entry["path"])
-    print(f"----------- [RL, DEBUG] Path length: {len(path)}: {path}")
     distance = path_distance(path)
 
     direct_distance = path_distance(test_entry["path"])


### PR DESCRIPTION
This is cheap to fix for the last triangle but can (and will) also happen for intermediate triangles with A*. The latter would be insanely expensive and defeat way the A* algorithm works. This has to be fixed by different routing algorithm.

Basically `straightenPath()` is called each time you hit the final destination triangle to ensure getting a shorter path if the funneling algorithm yields it.

A corresponding routing test is added that passes only with this fix.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1588/
<!-- PREVIEW-URL-END -->