### PR TITLE
Add Warpdriver to the model comparison notebook

### DIFF
--- a/notebooks/model-comparison.ipynb
+++ b/notebooks/model-comparison.ipynb
@@ -81,7 +81,7 @@
     "   An enhanced force-based model where agents experience centrifugal forces  \n",
     "  to better simulate realistic avoidance behavior.\n",
     "\n",
-    "5. [**Warp Driver**](https://www.jupedsim.org/stable/pedestrian_models/warp_driver_model.html)  \n",
+    "5. [**Warp Driver (WD):**](https://www.jupedsim.org/stable/pedestrian_models/warp_driver_model.html)  \n",
     "  The WarpDriver model computes collision-free velocities using **probabilistic collision fields**.\n",
     "\n",
     "> **Note:**  \n",

--- a/notebooks/model-comparison.ipynb
+++ b/notebooks/model-comparison.ipynb
@@ -81,7 +81,7 @@
     "   An enhanced force-based model where agents experience centrifugal forces  \n",
     "  to better simulate realistic avoidance behavior.\n",
     "\n",
-    "5. [**Warp Driver**](https://www.jupedsim.org/stable/pedestrian_models/warp_driver_model.html)\n",
+    "5. [**Warp Driver**](https://www.jupedsim.org/stable/pedestrian_models/warp_driver_model.html)  \n",
     "  The WarpDriver model computes collision-free velocities using **probabilistic collision fields**.\n",
     "\n",
     "> **Note:**  \n",
@@ -599,7 +599,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = \"CFM\"\n",
+    "model = \"CSM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
     "    jps.CollisionFreeSpeedModelV2(),\n",
@@ -844,7 +844,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = \"CFM\"\n",
+    "model = \"CSM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
     "    jps.CollisionFreeSpeedModelV2(),\n",
@@ -1106,7 +1106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = \"CFM\"\n",
+    "model = \"CSM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
     "    jps.CollisionFreeSpeedModelV2(),\n",
@@ -1381,7 +1381,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = \"CFM\"\n",
+    "model = \"CSM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
     "    jps.CollisionFreeSpeedModelV2(),\n",
@@ -1520,6 +1520,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "439f95b5",
    "metadata": {},
    "source": [
     "### WD Simulation"

--- a/notebooks/model-comparison.ipynb
+++ b/notebooks/model-comparison.ipynb
@@ -168,7 +168,7 @@
     "                    orientation=orientation,\n",
     "                )\n",
     "            )\n",
-    "        elif( agent_parameters == jps.WarpDriverModelAgentParameters):\n",
+    "        elif agent_parameters == jps.WarpDriverModelAgentParameters:\n",
     "            simulation.add_agent(\n",
     "                agent_parameters(\n",
     "                    journey_id=journey_id,\n",

--- a/notebooks/model-comparison.ipynb
+++ b/notebooks/model-comparison.ipynb
@@ -81,6 +81,9 @@
     "   An enhanced force-based model where agents experience centrifugal forces  \n",
     "  to better simulate realistic avoidance behavior.\n",
     "\n",
+    "5. [**Warp Driver**](https://www.jupedsim.org/stable/pedestrian_models/warp_driver_model.html)\n",
+    "  The WarpDriver model computes collision-free velocities using **probabilistic collision fields**.\n",
+    "\n",
     "> **Note:**  \n",
     "> All models are utilized with their default parameter settings as defined in **JuPedSim**."
    ]
@@ -156,6 +159,16 @@
     "            agent_parameters\n",
     "            == jps.GeneralizedCentrifugalForceModelAgentParameters\n",
     "        ):\n",
+    "            simulation.add_agent(\n",
+    "                agent_parameters(\n",
+    "                    journey_id=journey_id,\n",
+    "                    stage_id=exit_id,\n",
+    "                    desired_speed=v0,\n",
+    "                    position=pos,\n",
+    "                    orientation=orientation,\n",
+    "                )\n",
+    "            )\n",
+    "        elif( agent_parameters == jps.WarpDriverModelAgentParameters):\n",
     "            simulation.add_agent(\n",
     "                agent_parameters(\n",
     "                    journey_id=journey_id,\n",
@@ -318,7 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = \"CFM\"\n",
+    "model = \"CSM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
     "    jps.CollisionFreeSpeedModelV2(),\n",
@@ -437,6 +450,44 @@
     "simulation = initialize_simulation(\n",
     "    jps.GeneralizedCentrifugalForceModel(),\n",
     "    jps.GeneralizedCentrifugalForceModelAgentParameters,\n",
+    "    geometry,\n",
+    "    goals,\n",
+    "    positions,\n",
+    "    speeds,\n",
+    "    trajectory_file,\n",
+    ")\n",
+    "times_dict[model] = run_simulation(simulation, max_iterations=5000)\n",
+    "trajectories, walkable_area = read_sqlite_file(trajectory_file)\n",
+    "animate(\n",
+    "    trajectories,\n",
+    "    walkable_area,\n",
+    "    title_note=model,\n",
+    "    every_nth_frame=5,\n",
+    "    width=width,\n",
+    "    height=height,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d100502",
+   "metadata": {},
+   "source": [
+    "### WD Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05a71037",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = \"WD\"\n",
+    "trajectory_file = f\"{model}.sqlite\"\n",
+    "simulation = initialize_simulation(\n",
+    "    jps.WarpDriverModel(),\n",
+    "    jps.WarpDriverModelAgentParameters,\n",
     "    geometry,\n",
     "    goals,\n",
     "    positions,\n",
@@ -687,6 +738,44 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d0452c7c",
+   "metadata": {},
+   "source": [
+    "### WD Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2383398",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = \"WD\"\n",
+    "trajectory_file = f\"{model}.sqlite\"\n",
+    "simulation = initialize_simulation(\n",
+    "    jps.WarpDriverModel(),\n",
+    "    jps.WarpDriverModelAgentParameters,\n",
+    "    geometry,\n",
+    "    goals,\n",
+    "    positions,\n",
+    "    speeds,\n",
+    "    trajectory_file,\n",
+    ")\n",
+    "times_dict[model] = run_simulation(simulation, max_iterations=2000)\n",
+    "trajectories, walkable_area = read_sqlite_file(trajectory_file)\n",
+    "animate(\n",
+    "    trajectories,\n",
+    "    walkable_area,\n",
+    "    title_note=model,\n",
+    "    every_nth_frame=5,\n",
+    "    width=width,\n",
+    "    height=height,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6f9f6b1f",
    "metadata": {},
    "source": [
@@ -881,6 +970,44 @@
     "    trajectory_file,\n",
     ")\n",
     "times_dict[model] = run_simulation(simulation, max_iterations=5000)\n",
+    "trajectories, walkable_area = read_sqlite_file(trajectory_file)\n",
+    "animate(\n",
+    "    trajectories,\n",
+    "    walkable_area,\n",
+    "    title_note=model,\n",
+    "    every_nth_frame=5,\n",
+    "    width=width,\n",
+    "    height=height,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f2300e2",
+   "metadata": {},
+   "source": [
+    "### WD Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39c35073",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = \"WD\"\n",
+    "trajectory_file = f\"{model}.sqlite\"\n",
+    "simulation = initialize_simulation(\n",
+    "    jps.WarpDriverModel(),\n",
+    "    jps.WarpDriverModelAgentParameters,\n",
+    "    geometry,\n",
+    "    goals,\n",
+    "    positions,\n",
+    "    speeds,\n",
+    "    trajectory_file,\n",
+    ")\n",
+    "times_dict[model] = run_simulation(simulation, max_iterations=2000)\n",
     "trajectories, walkable_area = read_sqlite_file(trajectory_file)\n",
     "animate(\n",
     "    trajectories,\n",
@@ -1098,6 +1225,44 @@
     "simulation = initialize_simulation(\n",
     "    jps.GeneralizedCentrifugalForceModel(),\n",
     "    jps.GeneralizedCentrifugalForceModelAgentParameters,\n",
+    "    geometry,\n",
+    "    goals,\n",
+    "    positions,\n",
+    "    speeds,\n",
+    "    trajectory_file,\n",
+    ")\n",
+    "times_dict[model] = run_simulation(simulation, max_iterations=2000)\n",
+    "trajectories, walkable_area = read_sqlite_file(trajectory_file)\n",
+    "animate(\n",
+    "    trajectories,\n",
+    "    walkable_area,\n",
+    "    title_note=model,\n",
+    "    every_nth_frame=5,\n",
+    "    width=width,\n",
+    "    height=height,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc217db4",
+   "metadata": {},
+   "source": [
+    "### WD Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86433347",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = \"WD\"\n",
+    "trajectory_file = f\"{model}.sqlite\"\n",
+    "simulation = initialize_simulation(\n",
+    "    jps.WarpDriverModel(),\n",
+    "    jps.WarpDriverModelAgentParameters,\n",
     "    geometry,\n",
     "    goals,\n",
     "    positions,\n",
@@ -1355,7 +1520,44 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e079ea8-adf1-46a6-940c-020b5ccc5acd",
+   "metadata": {},
+   "source": [
+    "### WD Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37bee8bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = \"WD\"\n",
+    "trajectory_file = f\"{model}.sqlite\"\n",
+    "simulation = initialize_simulation(\n",
+    "    jps.WarpDriverModel(),\n",
+    "    jps.WarpDriverModelAgentParameters,\n",
+    "    geometry,\n",
+    "    goals,\n",
+    "    positions,\n",
+    "    speeds,\n",
+    "    trajectory_file,\n",
+    ")\n",
+    "times_dict[model] = run_simulation(simulation, max_iterations=2000)\n",
+    "trajectories, walkable_area = read_sqlite_file(trajectory_file)\n",
+    "animate(\n",
+    "    trajectories,\n",
+    "    walkable_area,\n",
+    "    title_note=model,\n",
+    "    every_nth_frame=5,\n",
+    "    width=width,\n",
+    "    height=height,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "987b5e9f",
    "metadata": {},
    "source": [
     "### Evacuation times"


### PR DESCRIPTION
I added the Warpdriver model to the model comparison notebook in the online documentation.
At the same time I changed, the name shown used in Python for the Collision-Free Speed Model to CSM as shown in all headings.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1592/
<!-- PREVIEW-URL-END -->