### PR TITLE
Remove operational model cloning

### DIFF
--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
-#include <memory>
 #include <numeric>
 #include <vector>
 
@@ -207,11 +206,6 @@ void AnticipationVelocityModel::CheckModelConstraint(
             agent.pos,
             r);
     }
-}
-
-std::unique_ptr<OperationalModel> AnticipationVelocityModel::Clone() const
-{
-    return std::make_unique<AnticipationVelocityModel>(*this);
 }
 
 double AnticipationVelocityModel::OptimalSpeed(

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.hpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.hpp
@@ -9,7 +9,6 @@
 #include "Point.hpp"
 
 #include <cstdint>
-#include <memory>
 #include <random>
 #include <vector>
 
@@ -40,7 +39,6 @@ public:
         const GenericAgent& agent,
         const NeighborhoodSearchType& neighborhoodSearch,
         const CollisionGeometry& geometry) const override;
-    std::unique_ptr<OperationalModel> Clone() const override;
 
 private:
     double OptimalSpeed(const GenericAgent& ped, double spacing, double time_gap) const;

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelBuilder.cpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelBuilder.cpp
@@ -12,7 +12,7 @@ AnticipationVelocityModelBuilder::AnticipationVelocityModelBuilder(
 {
 }
 
-AnticipationVelocityModel AnticipationVelocityModelBuilder::Build()
+std::unique_ptr<OperationalModel> AnticipationVelocityModelBuilder::Build()
 {
-    return AnticipationVelocityModel(pushoutStrength, rng_seed);
+    return std::make_unique<AnticipationVelocityModel>(pushoutStrength, rng_seed);
 }

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelBuilder.hpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelBuilder.hpp
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "AnticipationVelocityModel.hpp"
+#include "OperationalModel.hpp"
 
 #include <stdint.h>
+
+#include <memory>
 
 class AnticipationVelocityModelBuilder
 {
 public:
     AnticipationVelocityModelBuilder(double pushoutStrength, uint64_t rng_seed);
-    AnticipationVelocityModel Build();
+    std::unique_ptr<OperationalModel> Build();
 
 private:
     double pushoutStrength{};

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
@@ -16,7 +16,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <limits>
-#include <memory>
 #include <numeric>
 #include <vector>
 
@@ -160,11 +159,6 @@ void CollisionFreeSpeedModel::CheckModelConstraint(
             agent.pos,
             r);
     }
-}
-
-std::unique_ptr<OperationalModel> CollisionFreeSpeedModel::Clone() const
-{
-    return std::make_unique<CollisionFreeSpeedModel>(*this);
 }
 
 double CollisionFreeSpeedModel::OptimalSpeed(

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.hpp
@@ -8,8 +8,6 @@
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 
-#include <memory>
-
 struct GenericAgent;
 
 class CollisionFreeSpeedModel : public OperationalModel
@@ -42,7 +40,6 @@ public:
         const GenericAgent& agent,
         const NeighborhoodSearchType& neighborhoodSearch,
         const CollisionGeometry& geometry) const override;
-    std::unique_ptr<OperationalModel> Clone() const override;
 
 private:
     double OptimalSpeed(const GenericAgent& ped, double spacing, double time_gap) const;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelBuilder.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelBuilder.cpp
@@ -12,7 +12,7 @@ CollisionFreeSpeedModelBuilder::CollisionFreeSpeedModelBuilder(
 {
 }
 
-CollisionFreeSpeedModel CollisionFreeSpeedModelBuilder::Build()
+std::unique_ptr<OperationalModel> CollisionFreeSpeedModelBuilder::Build()
 {
-    return CollisionFreeSpeedModel(_aPed, _DPed, _aWall, _DWall);
+    return std::make_unique<CollisionFreeSpeedModel>(_aPed, _DPed, _aWall, _DWall);
 }

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelBuilder.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelBuilder.hpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "CollisionFreeSpeedModel.hpp"
+#include "OperationalModel.hpp"
+
+#include <memory>
+
 class CollisionFreeSpeedModelBuilder
 {
     double _aPed;
@@ -11,5 +14,5 @@ class CollisionFreeSpeedModelBuilder
 
 public:
     CollisionFreeSpeedModelBuilder(double aPed, double DPed, double aWall, double DWall);
-    CollisionFreeSpeedModel Build();
+    std::unique_ptr<OperationalModel> Build();
 };

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
@@ -16,7 +16,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <limits>
-#include <memory>
 #include <numeric>
 #include <vector>
 
@@ -148,11 +147,6 @@ void CollisionFreeSpeedModelV2::CheckModelConstraint(
             agent.pos,
             r);
     }
-}
-
-std::unique_ptr<OperationalModel> CollisionFreeSpeedModelV2::Clone() const
-{
-    return std::make_unique<CollisionFreeSpeedModelV2>(*this);
 }
 
 double CollisionFreeSpeedModelV2::OptimalSpeed(

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.hpp
@@ -8,8 +8,6 @@
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 
-#include <memory>
-
 struct GenericAgent;
 
 class CollisionFreeSpeedModelV2 : public OperationalModel
@@ -34,7 +32,6 @@ public:
         const GenericAgent& agent,
         const NeighborhoodSearchType& neighborhoodSearch,
         const CollisionGeometry& geometry) const override;
-    std::unique_ptr<OperationalModel> Clone() const override;
 
 private:
     double OptimalSpeed(const GenericAgent& ped, double spacing, double time_gap) const;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Builder.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Builder.cpp
@@ -7,7 +7,7 @@ CollisionFreeSpeedModelV2Builder::CollisionFreeSpeedModelV2Builder()
 {
 }
 
-CollisionFreeSpeedModelV2 CollisionFreeSpeedModelV2Builder::Build()
+std::unique_ptr<OperationalModel> CollisionFreeSpeedModelV2Builder::Build()
 {
-    return CollisionFreeSpeedModelV2();
+    return std::make_unique<CollisionFreeSpeedModelV2>();
 }

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Builder.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Builder.hpp
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "CollisionFreeSpeedModelV2.hpp"
+#include "OperationalModel.hpp"
+
+#include <memory>
+
 class CollisionFreeSpeedModelV2Builder
 {
 public:
     CollisionFreeSpeedModelV2Builder();
-    CollisionFreeSpeedModelV2 Build();
+    std::unique_ptr<OperationalModel> Build();
 };

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include <memory>
 #include <numeric>
 #include <vector>
 
@@ -212,11 +211,6 @@ void CollisionFreeSpeedModelV3::CheckModelConstraint(
             agent.pos,
             model.radius);
     }
-}
-
-std::unique_ptr<OperationalModel> CollisionFreeSpeedModelV3::Clone() const
-{
-    return std::make_unique<CollisionFreeSpeedModelV3>(*this);
 }
 
 double CollisionFreeSpeedModelV3::OptimalSpeed(

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.hpp
@@ -8,8 +8,6 @@
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 
-#include <memory>
-
 struct GenericAgent;
 
 class CollisionFreeSpeedModelV3 : public OperationalModel
@@ -34,7 +32,6 @@ public:
         const GenericAgent& agent,
         const NeighborhoodSearchType& neighborhoodSearch,
         const CollisionGeometry& geometry) const override;
-    std::unique_ptr<OperationalModel> Clone() const override;
 
 private:
     double OptimalSpeed(const GenericAgent& ped, double spacing, double time_gap) const;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3Builder.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3Builder.cpp
@@ -7,7 +7,7 @@ CollisionFreeSpeedModelV3Builder::CollisionFreeSpeedModelV3Builder()
 {
 }
 
-CollisionFreeSpeedModelV3 CollisionFreeSpeedModelV3Builder::Build()
+std::unique_ptr<OperationalModel> CollisionFreeSpeedModelV3Builder::Build()
 {
-    return CollisionFreeSpeedModelV3();
+    return std::make_unique<CollisionFreeSpeedModelV3>();
 }

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3Builder.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3Builder.hpp
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "CollisionFreeSpeedModelV3.hpp"
+#include "OperationalModel.hpp"
+
+#include <memory>
+
 class CollisionFreeSpeedModelV3Builder
 {
 public:
     CollisionFreeSpeedModelV3Builder();
-    CollisionFreeSpeedModelV3 Build();
+    std::unique_ptr<OperationalModel> Build();
 };

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -163,11 +163,6 @@ void GeneralizedCentrifugalForceModel::CheckModelConstraint(
     }
 }
 
-std::unique_ptr<OperationalModel> GeneralizedCentrifugalForceModel::Clone() const
-{
-    return std::make_unique<GeneralizedCentrifugalForceModel>(*this);
-}
-
 Point GeneralizedCentrifugalForceModel::ForceDriv(
     const GenericAgent& ped,
     Point target,

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.hpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.hpp
@@ -7,8 +7,6 @@
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 
-#include <memory>
-
 struct GenericAgent;
 
 class GeneralizedCentrifugalForceModel : public OperationalModel
@@ -49,7 +47,6 @@ public:
         const GenericAgent& agent,
         const NeighborhoodSearchType& neighborhoodSearch,
         const CollisionGeometry& geometry) const override;
-    std::unique_ptr<OperationalModel> Clone() const override;
 
 private:
     /**

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelBuilder.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelBuilder.cpp
@@ -23,9 +23,9 @@ GeneralizedCentrifugalForceModelBuilder::GeneralizedCentrifugalForceModelBuilder
 {
 }
 
-GeneralizedCentrifugalForceModel GeneralizedCentrifugalForceModelBuilder::Build()
+std::unique_ptr<OperationalModel> GeneralizedCentrifugalForceModelBuilder::Build()
 {
-    return GeneralizedCentrifugalForceModel(
+    return std::make_unique<GeneralizedCentrifugalForceModel>(
         _nuped,
         _nuwall,
         _dist_effPed,

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelBuilder.hpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelBuilder.hpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "GeneralizedCentrifugalForceModel.hpp"
+#include "OperationalModel.hpp"
+
+#include <memory>
 
 class GeneralizedCentrifugalForceModelBuilder
 {
@@ -24,5 +26,5 @@ public:
         double intp_widthwall,
         double maxfped,
         double maxfwall);
-    GeneralizedCentrifugalForceModel Build();
+    std::unique_ptr<OperationalModel> Build();
 };

--- a/libsimulator/src/OperationalModels/OperationalModel.hpp
+++ b/libsimulator/src/OperationalModels/OperationalModel.hpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "Clonable.hpp"
 #include "CollisionGeometry.hpp"
 #include "OperationalModelType.hpp"
 #include "OperationalModelUpdate.hpp"
@@ -76,7 +75,7 @@ void validateConstraint(
     }
 }
 
-class OperationalModel : public Clonable<OperationalModel>
+class OperationalModel
 {
 public:
     OperationalModel() = default;

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
@@ -12,7 +12,6 @@
 
 #include <cmath>
 #include <iterator>
-#include <memory>
 #include <numeric>
 #include <string>
 
@@ -22,11 +21,6 @@ SocialForceModel::SocialForceModel(double bodyForce_, double friction_)
 OperationalModelType SocialForceModel::Type() const
 {
     return OperationalModelType::SOCIAL_FORCE;
-}
-
-std::unique_ptr<OperationalModel> SocialForceModel::Clone() const
-{
-    return std::make_unique<SocialForceModel>(*this);
 }
 
 OperationalModelUpdate SocialForceModel::ComputeNewPosition(

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.hpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.hpp
@@ -8,8 +8,6 @@
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 
-#include <memory>
-
 struct GenericAgent;
 
 class SocialForceModel : public OperationalModel
@@ -36,7 +34,6 @@ public:
         const GenericAgent& agent,
         const NeighborhoodSearchType& neighborhoodSearch,
         const CollisionGeometry& geometry) const override;
-    std::unique_ptr<OperationalModel> Clone() const override;
 
 private:
     /**

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModelBuilder.cpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModelBuilder.cpp
@@ -8,7 +8,7 @@ SocialForceModelBuilder::SocialForceModelBuilder(double bodyForce, double fricti
 {
 }
 
-SocialForceModel SocialForceModelBuilder::Build()
+std::unique_ptr<OperationalModel> SocialForceModelBuilder::Build()
 {
-    return SocialForceModel(_bodyForce, _friction);
+    return std::make_unique<SocialForceModel>(_bodyForce, _friction);
 }

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModelBuilder.hpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModelBuilder.hpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "SocialForceModel.hpp"
+#include "OperationalModel.hpp"
+
+#include <memory>
+
 class SocialForceModelBuilder
 {
     double _bodyForce;
@@ -9,5 +12,5 @@ class SocialForceModelBuilder
 
 public:
     SocialForceModelBuilder(double bodyForce, double friction);
-    SocialForceModel Build();
+    std::unique_ptr<OperationalModel> Build();
 };

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
@@ -36,7 +36,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <memory>
 #include <variant>
 
 // ============================================================================
@@ -348,11 +347,6 @@ WarpDriverModel::WarpDriverModel(
 OperationalModelType WarpDriverModel::Type() const
 {
     return OperationalModelType::WARP_DRIVER;
-}
-
-std::unique_ptr<OperationalModel> WarpDriverModel::Clone() const
-{
-    return std::make_unique<WarpDriverModel>(*this);
 }
 
 void WarpDriverModel::ApplyUpdate(const OperationalModelUpdate& update, GenericAgent& agent) const

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.hpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.hpp
@@ -8,7 +8,6 @@
 #include "Point.hpp"
 
 #include <cstdint>
-#include <memory>
 #include <random>
 #include <vector>
 
@@ -85,6 +84,4 @@ public:
         const GenericAgent& agent,
         const NeighborhoodSearchType& neighborhoodSearch,
         const CollisionGeometry& geometry) const override;
-
-    std::unique_ptr<OperationalModel> Clone() const override;
 };

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelBuilder.cpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelBuilder.cpp
@@ -2,6 +2,7 @@
 #include "WarpDriverModelBuilder.hpp"
 
 #include "SimulationError.hpp"
+#include "WarpDriverModel.hpp"
 
 namespace
 {
@@ -29,7 +30,7 @@ WarpDriverModelBuilder::WarpDriverModelBuilder(
 {
 }
 
-WarpDriverModel WarpDriverModelBuilder::Build()
+std::unique_ptr<OperationalModel> WarpDriverModelBuilder::Build()
 {
     if(_timeHorizon <= 0.0) {
         throw SimulationError(
@@ -56,7 +57,7 @@ WarpDriverModel WarpDriverModelBuilder::Build()
             _velocityUncertaintyY);
     }
 
-    return WarpDriverModel(
+    return std::make_unique<WarpDriverModel>(
         _timeHorizon,
         _stepSize,
         _sigma,

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelBuilder.hpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelBuilder.hpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "WarpDriverModel.hpp"
+#include "OperationalModel.hpp"
+
+#include <memory>
 
 class WarpDriverModelBuilder
 {
@@ -20,5 +22,5 @@ public:
         double timeUncertainty = 0.5,
         double velocityUncertaintyX = 0.2,
         double velocityUncertaintyY = 0.2);
-    WarpDriverModel Build();
+    std::unique_ptr<OperationalModel> Build();
 };

--- a/python_bindings_jupedsim/anticipation_velocity_model.cpp
+++ b/python_bindings_jupedsim/anticipation_velocity_model.cpp
@@ -12,7 +12,8 @@ namespace py = pybind11;
 
 void init_anticipation_velocity_model(py::module_& m)
 {
-    py::class_<AnticipationVelocityModel, OperationalModel>(m, "AnticipationVelocityModel");
+    py::class_<AnticipationVelocityModel, OperationalModel, py::smart_holder>(
+        m, "AnticipationVelocityModel");
     py::class_<AnticipationVelocityModelBuilder>(m, "AnticipationVelocityModelBuilder")
         .def(
             py::init<double, double>(),

--- a/python_bindings_jupedsim/collision_free_speed_model.cpp
+++ b/python_bindings_jupedsim/collision_free_speed_model.cpp
@@ -12,7 +12,8 @@ namespace py = pybind11;
 
 void init_collision_free_speed_model(py::module_& m)
 {
-    py::class_<CollisionFreeSpeedModel, OperationalModel>(m, "CollisionFreeSpeedModel");
+    py::class_<CollisionFreeSpeedModel, OperationalModel, py::smart_holder>(
+        m, "CollisionFreeSpeedModel");
     py::class_<CollisionFreeSpeedModelBuilder>(m, "CollisionFreeSpeedModelBuilder")
         .def(
             py::init<double, double, double, double>(),

--- a/python_bindings_jupedsim/collision_free_speed_model_v2.cpp
+++ b/python_bindings_jupedsim/collision_free_speed_model_v2.cpp
@@ -12,7 +12,8 @@ namespace py = pybind11;
 
 void init_collision_free_speed_model_v2(py::module_& m)
 {
-    py::class_<CollisionFreeSpeedModelV2, OperationalModel>(m, "CollisionFreeSpeedModelV2");
+    py::class_<CollisionFreeSpeedModelV2, OperationalModel, py::smart_holder>(
+        m, "CollisionFreeSpeedModelV2");
     py::class_<CollisionFreeSpeedModelV2Builder>(m, "CollisionFreeSpeedModelV2Builder")
         .def(py::init<>())
         .def("build", &CollisionFreeSpeedModelV2Builder::Build);

--- a/python_bindings_jupedsim/collision_free_speed_model_v3.cpp
+++ b/python_bindings_jupedsim/collision_free_speed_model_v3.cpp
@@ -12,7 +12,8 @@ namespace py = pybind11;
 
 void init_collision_free_speed_model_v3(py::module_& m)
 {
-    py::class_<CollisionFreeSpeedModelV3, OperationalModel>(m, "CollisionFreeSpeedModelV3");
+    py::class_<CollisionFreeSpeedModelV3, OperationalModel, py::smart_holder>(
+        m, "CollisionFreeSpeedModelV3");
     py::class_<CollisionFreeSpeedModelV3Builder>(m, "CollisionFreeSpeedModelV3Builder")
         .def(py::init<>())
         .def("build", &CollisionFreeSpeedModelV3Builder::Build);
@@ -67,8 +68,7 @@ void init_collision_free_speed_model_v3(py::module_& m)
             "range_geometry_repulsion", &CollisionFreeSpeedModelV3Data::rangeGeometryRepulsion)
         .def_readwrite("range_x_scale", &CollisionFreeSpeedModelV3Data::rangeXScale)
         .def_readwrite("range_y_scale", &CollisionFreeSpeedModelV3Data::rangeYScale)
-        .def_readwrite(
-            "theta_max_upper_bound", &CollisionFreeSpeedModelV3Data::thetaMaxUpperBound)
+        .def_readwrite("theta_max_upper_bound", &CollisionFreeSpeedModelV3Data::thetaMaxUpperBound)
         .def_readwrite("agent_buffer", &CollisionFreeSpeedModelV3Data::agentBuffer)
         .def_readwrite("time_gap", &CollisionFreeSpeedModelV3Data::timeGap)
         .def_readwrite("desired_speed", &CollisionFreeSpeedModelV3Data::v0)

--- a/python_bindings_jupedsim/generalized_centrifugal_force_model.cpp
+++ b/python_bindings_jupedsim/generalized_centrifugal_force_model.cpp
@@ -15,8 +15,8 @@ namespace py = pybind11;
 
 void init_generalized_centrifugal_force_model(py::module_& m)
 {
-    py::class_<OperationalModel>(m, "OperationalModel");
-    py::class_<GeneralizedCentrifugalForceModel, OperationalModel>(
+    py::class_<OperationalModel, py::smart_holder>(m, "OperationalModel");
+    py::class_<GeneralizedCentrifugalForceModel, OperationalModel, py::smart_holder>(
         m, "GeneralizedCentrifugalForceModel");
     py::class_<GeneralizedCentrifugalForceModelBuilder>(
         m, "GeneralizedCentrifugalForceModelBuilder")
@@ -33,8 +33,7 @@ void init_generalized_centrifugal_force_model(py::module_& m)
             py::arg("max_geometry_repulsion_force"))
         .def("build", &GeneralizedCentrifugalForceModelBuilder::Build);
     py::class_<GeneralizedCentrifugalForceModelData>(m, "GeneralizedCentrifugalForceModelState")
-        .def_static(
-            "_defaults", []() { return GeneralizedCentrifugalForceModelData{}; })
+        .def_static("_defaults", []() { return GeneralizedCentrifugalForceModelData{}; })
         .def(
             py::init([](double speed,
                         std::tuple<double, double> desiredOrientation,

--- a/python_bindings_jupedsim/simulation.cpp
+++ b/python_bindings_jupedsim/simulation.cpp
@@ -28,13 +28,17 @@ void init_simulation(py::module_& m)
 {
     py::class_<Simulation>(m, "Simulation")
         .def(
-            py::init([](const OperationalModel* model, CollisionGeometry geometry, double dT) {
-                if(!model) {
-                    throw std::invalid_argument("model must not be None");
-                }
-                return std::make_unique<Simulation>(
-                    model->Clone(), std::make_unique<CollisionGeometry>(geometry), dT);
-            }),
+            // The model is moved out of the Python object into Simulation. After this constructor
+            // returns, the Python model object passed here is disowned/invalid and must not be
+            // reused.
+            py::init(
+                [](std::unique_ptr<OperationalModel> model, CollisionGeometry geometry, double dT) {
+                    if(!model) {
+                        throw std::invalid_argument("model must not be None");
+                    }
+                    return std::make_unique<Simulation>(
+                        std::move(model), std::make_unique<CollisionGeometry>(geometry), dT);
+                }),
             py::kw_only(),
             py::arg("model"),
             py::arg("geometry"),

--- a/python_bindings_jupedsim/social_force_model.cpp
+++ b/python_bindings_jupedsim/social_force_model.cpp
@@ -15,7 +15,7 @@ namespace py = pybind11;
 
 void init_social_force_model(py::module_& m)
 {
-    py::class_<SocialForceModel, OperationalModel>(m, "SocialForceModel");
+    py::class_<SocialForceModel, OperationalModel, py::smart_holder>(m, "SocialForceModel");
     py::class_<SocialForceModelBuilder>(m, "SocialForceModelBuilder")
         .def(py::init<double, double>(), py::kw_only(), py::arg("body_force"), py::arg("friction"))
         .def("build", &SocialForceModelBuilder::Build);

--- a/python_bindings_jupedsim/warp_driver_model.cpp
+++ b/python_bindings_jupedsim/warp_driver_model.cpp
@@ -10,7 +10,7 @@ namespace py = pybind11;
 
 void init_warp_driver_model(py::module_& m)
 {
-    py::class_<WarpDriverModel, OperationalModel>(m, "WarpDriverModel");
+    py::class_<WarpDriverModel, OperationalModel, py::smart_holder>(m, "WarpDriverModel");
     py::class_<WarpDriverModelBuilder>(m, "WarpDriverModelBuilder")
         .def(
             py::init<double, double, double, double, double, double>(),


### PR DESCRIPTION
Move operational model ownership through the Python bindings with py::smart_holder and std::unique_ptr transfer into Simulation. This removes the unused Clone requirement from the operational model interface while keeping mesh/routing cloning unchanged.

Models are now moved out of their Python holder when creating the Simulation. The moved-from native model object is only created by the public jupedsim wrapper and is not exposed through the public Python API, so invalidating it after Simulation construction is a conscious trade-off.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1600/
<!-- PREVIEW-URL-END -->