### PR TITLE
Move orientation from GenericAgent to ModelData

### DIFF
--- a/examples/example_csv_writer.py
+++ b/examples/example_csv_writer.py
@@ -37,9 +37,7 @@ class CsvTrajectoryWriter(TrajectoryWriter):
     def begin_writing(self, simulation: Simulation) -> None:
         self._file = open(self._output_file, "w", newline="")
         self._csv_writer = csv.writer(self._file)
-        self._csv_writer.writerow(
-            ["frame", "id", "pos_x", "pos_y", "ori_x", "ori_y"]
-        )
+        self._csv_writer.writerow(["frame", "id", "pos_x", "pos_y"])
 
     def write_iteration_state(self, simulation: Simulation) -> None:
         iteration = simulation.iteration_count()
@@ -54,8 +52,6 @@ class CsvTrajectoryWriter(TrajectoryWriter):
                     agent.id,
                     agent.position[0],
                     agent.position[1],
-                    agent.orientation[0],
-                    agent.orientation[1],
                 ]
             )
 

--- a/libsimulator/CMakeLists.txt
+++ b/libsimulator/CMakeLists.txt
@@ -85,6 +85,7 @@ target_link_libraries(simulator PUBLIC
 target_link_options(simulator PUBLIC
     $<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>,$<BOOL:${BUILD_WITH_SANITIZERS}>>:-fsanitize=address,undefined>
     $<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>,$<BOOL:${BUILD_WITH_SANITIZERS}>>:-shared-libasan>
+    $<$<CXX_COMPILER_ID:GNU>:-Werror=odr>  # error out if LTO finds multiple definitions
 )
 target_include_directories(simulator PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/libsimulator/src/GenericAgent.hpp
+++ b/libsimulator/src/GenericAgent.hpp
@@ -32,7 +32,6 @@ struct GenericAgent {
 
     // Agent fields common for all models
     Point pos{};
-    Point orientation{};
 
     using Model = std::variant<
         GeneralizedCentrifugalForceModelData,
@@ -49,14 +48,12 @@ struct GenericAgent {
         jps::UniqueID<Journey> journeyId_,
         jps::UniqueID<BaseStage> stageId_,
         Point pos_,
-        Point orientation_,
         Model model_)
         : id(id_ != ID::Invalid ? id_ : ID{})
         , journeyId(journeyId_)
         , stageId(stageId_)
         , target(pos_)
         , pos(pos_)
-        , orientation(orientation_)
         , model(std::move(model_))
     {
     }
@@ -77,14 +74,13 @@ struct fmt::formatter<GenericAgent> {
                 return fmt::format_to(
                     ctx.out(),
                     "Agent[id={}, journey={}, stage={}, destination={}, waypoint={}, pos={}, "
-                    "orientation={}, model={})",
+                    "model={})",
                     agent.id,
                     agent.journeyId,
                     agent.stageId,
                     agent.destination,
                     agent.target,
                     agent.pos,
-                    agent.orientation,
                     m);
             },
             agent.model);

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
@@ -74,11 +74,11 @@ OperationalModelUpdate AnticipationVelocityModel::ComputeNewPosition(
 
     const auto desiredDirection = (ped.destination - ped.pos).Normalized();
     auto direction = (desiredDirection + neighborRepulsion).Normalized();
+    const auto& model = std::get<AnticipationVelocityModelData>(ped.model);
     if(direction == Point{}) {
-        direction = ped.orientation;
+        direction = model.orientation;
     }
 
-    const auto& model = std::get<AnticipationVelocityModelData>(ped.model);
     const double wallBufferDistance = model.wallBufferDistance;
     // Wall sliding behavior
 
@@ -106,7 +106,7 @@ void AnticipationVelocityModel::ApplyUpdate(const OperationalModelUpdate& upd, G
     const auto& update = std::get<AnticipationVelocityModelUpdate>(upd);
     auto& model = std::get<AnticipationVelocityModelData>(agent.model);
     agent.pos = update.position;
-    agent.orientation = update.orientation;
+    model.orientation = update.orientation;
     model.velocity = update.velocity;
 }
 
@@ -117,7 +117,7 @@ Point AnticipationVelocityModel::UpdateDirection(
 {
     const auto& model = std::get<AnticipationVelocityModelData>(ped.model);
     const Point desiredDirection = (ped.destination - ped.pos).Normalized();
-    const Point actualDirection = ped.orientation;
+    const Point actualDirection = model.orientation;
     Point updatedDirection;
 
     if(desiredDirection.ScalarProduct(calculatedDirection) *
@@ -280,9 +280,9 @@ Point AnticipationVelocityModel::NeighborRepulsion(
     const double adjustedDist = distance - (model1.radius + model2.radius);
 
     // Pedestrian movement and desired directions
-    const auto& e1 = ped1.orientation;
+    const auto& e1 = model1.orientation;
     const auto& d1 = (ped1.destination - ped1.pos).Normalized();
-    const auto& e2 = ped2.orientation;
+    const auto& e2 = model2.orientation;
 
     // Check perception range (Eq. 1)
     const auto inPerceptionRange = d1.ScalarProduct(ep12) >= 0 || e1.ScalarProduct(ep12) >= 0;

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelData.hpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelData.hpp
@@ -6,7 +6,7 @@
 #include <fmt/core.h>
 
 struct AnticipationVelocityModelData {
-    Point orientation{1.0, 0.0};
+    Point orientation{0.0, 0.0};
     double strengthNeighborRepulsion{8.0};
     double rangeNeighborRepulsion{0.1};
     double wallBufferDistance{0.1}; // buff distance of agent to wall

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelData.hpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelData.hpp
@@ -6,6 +6,7 @@
 #include <fmt/core.h>
 
 struct AnticipationVelocityModelData {
+    Point orientation{0.0, 0.0};
     double strengthNeighborRepulsion{8.0};
     double rangeNeighborRepulsion{0.1};
     double wallBufferDistance{0.1}; // buff distance of agent to wall
@@ -15,6 +16,29 @@ struct AnticipationVelocityModelData {
     double timeGap{1.06};
     double v0{1.2};
     double radius{0.2};
+
+    AnticipationVelocityModelData() = default;
+    AnticipationVelocityModelData(
+        Point orientation_,
+        double strengthNeighborRepulsion_,
+        double rangeNeighborRepulsion_,
+        double wallBufferDistance_,
+        double anticipationTime_,
+        double reactionTime_,
+        double timeGap_,
+        double v0_,
+        double radius_)
+        : orientation(orientation_.Normalized())
+        , strengthNeighborRepulsion(strengthNeighborRepulsion_)
+        , rangeNeighborRepulsion(rangeNeighborRepulsion_)
+        , wallBufferDistance(wallBufferDistance_)
+        , anticipationTime(anticipationTime_)
+        , reactionTime(reactionTime_)
+        , timeGap(timeGap_)
+        , v0(v0_)
+        , radius(radius_)
+    {
+    }
 };
 
 template <>
@@ -27,9 +51,10 @@ struct fmt::formatter<AnticipationVelocityModelData> {
     {
         return fmt::format_to(
             ctx.out(),
-            "AnticipationVelocityModel[strengthNeighborRepulsion={}, "
+            "AnticipationVelocityModel[orientation={}, strengthNeighborRepulsion={}, "
             "rangeNeighborRepulsion={}, wallBufferDistance={}, "
             "timeGap={}, v0={}, radius={}, reactionTime={}, anticipationTime={}, velocity={}])",
+            m.orientation,
             m.strengthNeighborRepulsion,
             m.rangeNeighborRepulsion,
             m.wallBufferDistance,

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelData.hpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelData.hpp
@@ -6,7 +6,7 @@
 #include <fmt/core.h>
 
 struct AnticipationVelocityModelData {
-    Point orientation{0.0, 0.0};
+    Point orientation{1.0, 0.0};
     double strengthNeighborRepulsion{8.0};
     double rangeNeighborRepulsion{0.1};
     double wallBufferDistance{0.1}; // buff distance of agent to wall
@@ -16,29 +16,6 @@ struct AnticipationVelocityModelData {
     double timeGap{1.06};
     double v0{1.2};
     double radius{0.2};
-
-    AnticipationVelocityModelData() = default;
-    AnticipationVelocityModelData(
-        Point orientation_,
-        double strengthNeighborRepulsion_,
-        double rangeNeighborRepulsion_,
-        double wallBufferDistance_,
-        double anticipationTime_,
-        double reactionTime_,
-        double timeGap_,
-        double v0_,
-        double radius_)
-        : orientation(orientation_.Normalized())
-        , strengthNeighborRepulsion(strengthNeighborRepulsion_)
-        , rangeNeighborRepulsion(rangeNeighborRepulsion_)
-        , wallBufferDistance(wallBufferDistance_)
-        , anticipationTime(anticipationTime_)
-        , reactionTime(reactionTime_)
-        , timeGap(timeGap_)
-        , v0(v0_)
-        , radius(radius_)
-    {
-    }
 };
 
 template <>

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
@@ -87,8 +87,9 @@ OperationalModelUpdate CollisionFreeSpeedModel::ComputeNewPosition(
 
     const auto desired_direction = (ped.destination - ped.pos).Normalized();
     auto direction = (desired_direction + neighborRepulsion + boundaryRepulsion).Normalized();
+    const auto& model = std::get<CollisionFreeSpeedModelData>(ped.model);
     if(direction == Point{}) {
-        direction = ped.orientation;
+        direction = model.orientation;
     }
     const auto spacing = std::accumulate(
         std::begin(neighborhood),
@@ -98,7 +99,6 @@ OperationalModelUpdate CollisionFreeSpeedModel::ComputeNewPosition(
             return std::min(res, GetSpacing(ped, neighbor, direction));
         });
 
-    const auto& model = std::get<CollisionFreeSpeedModelData>(ped.model);
     const auto optimal_speed = OptimalSpeed(ped, spacing, model.timeGap);
     const auto velocity = direction * optimal_speed;
     return CollisionFreeSpeedModelUpdate{ped.pos + velocity * dT, direction};
@@ -108,8 +108,9 @@ void CollisionFreeSpeedModel::ApplyUpdate(const OperationalModelUpdate& upd, Gen
     const
 {
     const auto& update = std::get<CollisionFreeSpeedModelUpdate>(upd);
+    auto& model = std::get<CollisionFreeSpeedModelData>(agent.model);
     agent.pos = update.position;
-    agent.orientation = update.orientation;
+    model.orientation = update.orientation;
 }
 
 void CollisionFreeSpeedModel::CheckModelConstraint(

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelData.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelData.hpp
@@ -4,9 +4,16 @@
 #include <fmt/core.h>
 
 struct CollisionFreeSpeedModelData {
+    Point orientation{0.0, 0.0};
     double timeGap{1};
     double v0{1.2};
     double radius{0.2};
+
+    CollisionFreeSpeedModelData() = default;
+    CollisionFreeSpeedModelData(Point orientation_, double timeGap_, double v0_, double radius_)
+        : orientation(orientation_.Normalized()), timeGap(timeGap_), v0(v0_), radius(radius_)
+    {
+    }
 };
 
 template <>
@@ -19,7 +26,8 @@ struct fmt::formatter<CollisionFreeSpeedModelData> {
     {
         return fmt::format_to(
             ctx.out(),
-            "CollisionFreeSpeedModel[timeGap={}, v0={}, radius={}])",
+            "CollisionFreeSpeedModel[orientation={}, timeGap={}, v0={}, radius={}])",
+            m.orientation,
             m.timeGap,
             m.v0,
             m.radius);

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelData.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelData.hpp
@@ -4,7 +4,7 @@
 #include <fmt/core.h>
 
 struct CollisionFreeSpeedModelData {
-    Point orientation{1.0, 0.0};
+    Point orientation{0.0, 0.0};
     double timeGap{1};
     double v0{1.2};
     double radius{0.2};

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelData.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelData.hpp
@@ -4,16 +4,10 @@
 #include <fmt/core.h>
 
 struct CollisionFreeSpeedModelData {
-    Point orientation{0.0, 0.0};
+    Point orientation{1.0, 0.0};
     double timeGap{1};
     double v0{1.2};
     double radius{0.2};
-
-    CollisionFreeSpeedModelData() = default;
-    CollisionFreeSpeedModelData(Point orientation_, double timeGap_, double v0_, double radius_)
-        : orientation(orientation_.Normalized()), timeGap(timeGap_), v0(v0_), radius(radius_)
-    {
-    }
 };
 
 template <>

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
@@ -75,8 +75,9 @@ OperationalModelUpdate CollisionFreeSpeedModelV2::ComputeNewPosition(
 
     const auto desired_direction = (ped.destination - ped.pos).Normalized();
     auto direction = (desired_direction + neighborRepulsion + boundaryRepulsion).Normalized();
+    const auto& model = std::get<CollisionFreeSpeedModelV2Data>(ped.model);
     if(direction == Point{}) {
-        direction = ped.orientation;
+        direction = model.orientation;
     }
     const auto spacing = std::accumulate(
         std::begin(neighborhood),
@@ -86,7 +87,6 @@ OperationalModelUpdate CollisionFreeSpeedModelV2::ComputeNewPosition(
             return std::min(res, GetSpacing(ped, neighbor, direction));
         });
 
-    const auto& model = std::get<CollisionFreeSpeedModelV2Data>(ped.model);
     const auto optimal_speed = OptimalSpeed(ped, spacing, model.timeGap);
     const auto velocity = direction * optimal_speed;
     return CollisionFreeSpeedModelV2Update{ped.pos + velocity * dT, direction};
@@ -96,8 +96,9 @@ void CollisionFreeSpeedModelV2::ApplyUpdate(const OperationalModelUpdate& upd, G
     const
 {
     const auto& update = std::get<CollisionFreeSpeedModelV2Update>(upd);
+    auto& model = std::get<CollisionFreeSpeedModelV2Data>(agent.model);
     agent.pos = update.position;
-    agent.orientation = update.orientation;
+    model.orientation = update.orientation;
 }
 
 void CollisionFreeSpeedModelV2::CheckModelConstraint(

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Data.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Data.hpp
@@ -4,6 +4,7 @@
 #include <fmt/core.h>
 
 struct CollisionFreeSpeedModelV2Data {
+    Point orientation{0.0, 0.0};
     double strengthNeighborRepulsion{8.0};
     double rangeNeighborRepulsion{0.1};
     double strengthGeometryRepulsion{5.0};
@@ -12,6 +13,27 @@ struct CollisionFreeSpeedModelV2Data {
     double timeGap{1};
     double v0{1.2};
     double radius{0.2};
+
+    CollisionFreeSpeedModelV2Data() = default;
+    CollisionFreeSpeedModelV2Data(
+        Point orientation_,
+        double strengthNeighborRepulsion_,
+        double rangeNeighborRepulsion_,
+        double strengthGeometryRepulsion_,
+        double rangeGeometryRepulsion_,
+        double timeGap_,
+        double v0_,
+        double radius_)
+        : orientation(orientation_.Normalized())
+        , strengthNeighborRepulsion(strengthNeighborRepulsion_)
+        , rangeNeighborRepulsion(rangeNeighborRepulsion_)
+        , strengthGeometryRepulsion(strengthGeometryRepulsion_)
+        , rangeGeometryRepulsion(rangeGeometryRepulsion_)
+        , timeGap(timeGap_)
+        , v0(v0_)
+        , radius(radius_)
+    {
+    }
 };
 
 template <>
@@ -24,9 +46,10 @@ struct fmt::formatter<CollisionFreeSpeedModelV2Data> {
     {
         return fmt::format_to(
             ctx.out(),
-            "CollisionFreeSpeedModelV2[strengthNeighborRepulsion={}, "
+            "CollisionFreeSpeedModelV2[orientation={}, strengthNeighborRepulsion={}, "
             "rangeNeighborRepulsion={}, strengthGeometryRepulsion={}, rangeGeometryRepulsion={}, "
             "timeGap={}, v0={}, radius={}])",
+            m.orientation,
             m.strengthNeighborRepulsion,
             m.rangeNeighborRepulsion,
             m.strengthGeometryRepulsion,

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Data.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Data.hpp
@@ -4,7 +4,7 @@
 #include <fmt/core.h>
 
 struct CollisionFreeSpeedModelV2Data {
-    Point orientation{0.0, 0.0};
+    Point orientation{1.0, 0.0};
     double strengthNeighborRepulsion{8.0};
     double rangeNeighborRepulsion{0.1};
     double strengthGeometryRepulsion{5.0};
@@ -13,27 +13,6 @@ struct CollisionFreeSpeedModelV2Data {
     double timeGap{1};
     double v0{1.2};
     double radius{0.2};
-
-    CollisionFreeSpeedModelV2Data() = default;
-    CollisionFreeSpeedModelV2Data(
-        Point orientation_,
-        double strengthNeighborRepulsion_,
-        double rangeNeighborRepulsion_,
-        double strengthGeometryRepulsion_,
-        double rangeGeometryRepulsion_,
-        double timeGap_,
-        double v0_,
-        double radius_)
-        : orientation(orientation_.Normalized())
-        , strengthNeighborRepulsion(strengthNeighborRepulsion_)
-        , rangeNeighborRepulsion(rangeNeighborRepulsion_)
-        , strengthGeometryRepulsion(strengthGeometryRepulsion_)
-        , rangeGeometryRepulsion(rangeGeometryRepulsion_)
-        , timeGap(timeGap_)
-        , v0(v0_)
-        , radius(radius_)
-    {
-    }
 };
 
 template <>

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Data.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2Data.hpp
@@ -4,7 +4,7 @@
 #include <fmt/core.h>
 
 struct CollisionFreeSpeedModelV2Data {
-    Point orientation{1.0, 0.0};
+    Point orientation{0.0, 0.0};
     double strengthNeighborRepulsion{8.0};
     double rangeNeighborRepulsion{0.1};
     double strengthGeometryRepulsion{5.0};

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
@@ -100,7 +100,7 @@ OperationalModelUpdate CollisionFreeSpeedModelV3::ComputeNewPosition(
     const auto desired_direction = (ped.destination - ped.pos).Normalized();
     auto reference_direction = (desired_direction + boundaryRepulsion).Normalized();
     if(reference_direction == Point{}) {
-        reference_direction = ped.orientation;
+        reference_direction = model.orientation;
     }
 
     const auto heading_target =
@@ -144,8 +144,8 @@ void CollisionFreeSpeedModelV3::ApplyUpdate(const OperationalModelUpdate& upd, G
 {
     const auto& update = std::get<CollisionFreeSpeedModelV3Update>(upd);
     agent.pos = update.position;
-    agent.orientation = update.orientation;
     auto& model = std::get<CollisionFreeSpeedModelV3Data>(agent.model);
+    model.orientation = update.orientation;
     model.headingAngle = update.headingAngle;
 }
 

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3Data.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3Data.hpp
@@ -4,6 +4,7 @@
 #include <fmt/core.h>
 
 struct CollisionFreeSpeedModelV3Data {
+    Point orientation{0.0, 0.0};
     double strengthNeighborRepulsion{}; // [rad] max steering authority before upper bound
     double rangeNeighborRepulsion{}; // [m] base interaction range for neighbor influence
     double strengthGeometryRepulsion{}; // [-] wall repulsion strength
@@ -18,6 +19,35 @@ struct CollisionFreeSpeedModelV3Data {
     double v0{1.2};
     double radius{0.15};
     double headingAngle{0.0}; // [rad] persistent relaxed heading state
+
+    CollisionFreeSpeedModelV3Data() = default;
+    CollisionFreeSpeedModelV3Data(
+        Point orientation_,
+        double strengthNeighborRepulsion_,
+        double rangeNeighborRepulsion_,
+        double strengthGeometryRepulsion_,
+        double rangeGeometryRepulsion_,
+        double rangeXScale_,
+        double rangeYScale_,
+        double thetaMaxUpperBound_,
+        double agentBuffer_,
+        double timeGap_,
+        double v0_,
+        double radius_)
+        : orientation(orientation_.Normalized())
+        , strengthNeighborRepulsion(strengthNeighborRepulsion_)
+        , rangeNeighborRepulsion(rangeNeighborRepulsion_)
+        , strengthGeometryRepulsion(strengthGeometryRepulsion_)
+        , rangeGeometryRepulsion(rangeGeometryRepulsion_)
+        , rangeXScale(rangeXScale_)
+        , rangeYScale(rangeYScale_)
+        , thetaMaxUpperBound(thetaMaxUpperBound_)
+        , agentBuffer(agentBuffer_)
+        , timeGap(timeGap_)
+        , v0(v0_)
+        , radius(radius_)
+    {
+    }
 };
 
 template <>
@@ -30,10 +60,11 @@ struct fmt::formatter<CollisionFreeSpeedModelV3Data> {
     {
         return fmt::format_to(
             ctx.out(),
-            "CollisionFreeSpeedModelV3[strengthNeighborRepulsion={}, "
+            "CollisionFreeSpeedModelV3[orientation={}, strengthNeighborRepulsion={}, "
             "rangeNeighborRepulsion={}, strengthGeometryRepulsion={}, rangeGeometryRepulsion={}, "
             "rangeXScale={}, rangeYScale={}, thetaMaxUpperBound={}, agentBuffer={}, "
             "timeGap={}, v0={}, radius={}, headingAngle={}])",
+            m.orientation,
             m.strengthNeighborRepulsion,
             m.rangeNeighborRepulsion,
             m.strengthGeometryRepulsion,

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3Data.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3Data.hpp
@@ -4,7 +4,7 @@
 #include <fmt/core.h>
 
 struct CollisionFreeSpeedModelV3Data {
-    Point orientation{0.0, 0.0};
+    Point orientation{1.0, 0.0};
     double strengthNeighborRepulsion{}; // [rad] max steering authority before upper bound
     double rangeNeighborRepulsion{}; // [m] base interaction range for neighbor influence
     double strengthGeometryRepulsion{}; // [-] wall repulsion strength
@@ -19,35 +19,6 @@ struct CollisionFreeSpeedModelV3Data {
     double v0{1.2};
     double radius{0.15};
     double headingAngle{0.0}; // [rad] persistent relaxed heading state
-
-    CollisionFreeSpeedModelV3Data() = default;
-    CollisionFreeSpeedModelV3Data(
-        Point orientation_,
-        double strengthNeighborRepulsion_,
-        double rangeNeighborRepulsion_,
-        double strengthGeometryRepulsion_,
-        double rangeGeometryRepulsion_,
-        double rangeXScale_,
-        double rangeYScale_,
-        double thetaMaxUpperBound_,
-        double agentBuffer_,
-        double timeGap_,
-        double v0_,
-        double radius_)
-        : orientation(orientation_.Normalized())
-        , strengthNeighborRepulsion(strengthNeighborRepulsion_)
-        , rangeNeighborRepulsion(rangeNeighborRepulsion_)
-        , strengthGeometryRepulsion(strengthGeometryRepulsion_)
-        , rangeGeometryRepulsion(rangeGeometryRepulsion_)
-        , rangeXScale(rangeXScale_)
-        , rangeYScale(rangeYScale_)
-        , thetaMaxUpperBound(thetaMaxUpperBound_)
-        , agentBuffer(agentBuffer_)
-        , timeGap(timeGap_)
-        , v0(v0_)
-        , radius(radius_)
-    {
-    }
 };
 
 template <>

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -98,7 +98,7 @@ void GeneralizedCentrifugalForceModel::CheckModelConstraint(
 {
     const auto& model = std::get<GeneralizedCentrifugalForceModelData>(agent.model);
 
-    if(model.orientation.isZeroLength()) {
+    if(!model.orientation.IsUnitLength(1e-9)) {
         throw SimulationError("Orientation is invalid: {}. Length should be 1.", model.orientation);
     }
 

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -68,7 +68,7 @@ OperationalModelUpdate GeneralizedCentrifugalForceModel::ComputeNewPosition(
     Point fd = ForceDriv(agent, agent.destination, model.mass, model.tau, dT, update);
     Point acc = (fd + F_rep + repwall) / model.mass;
 
-    update.velocity = (agent.orientation * model.speed) + acc * dT;
+    update.velocity = (model.orientation * model.speed) + acc * dT;
     update.position = agent.pos + *update.velocity * dT;
     return update;
 }
@@ -85,7 +85,7 @@ void GeneralizedCentrifugalForceModel::ApplyUpdate(
         agent.pos = *update.position;
     }
     if(update.velocity) {
-        agent.orientation = (*update.velocity).Normalized();
+        model.orientation = (*update.velocity).Normalized();
         model.speed = (*update.velocity).Norm();
     }
 }
@@ -180,10 +180,10 @@ Point GeneralizedCentrifugalForceModel::ForceDriv(
 
         const Point e0 = mollify_e0(target, pos, deltaT, model.orientationDelay, model.e0);
         update.e0 = e0;
-        F_driv = ((e0 * model.v0 - (ped.orientation * model.speed)) * mass) / tau;
+        F_driv = ((e0 * model.v0 - (model.orientation * model.speed)) * mass) / tau;
     } else {
         const Point e0 = model.e0;
-        F_driv = ((e0 * model.v0 - (ped.orientation * model.speed)) * mass) / tau;
+        F_driv = ((e0 * model.v0 - (model.orientation * model.speed)) * mass) / tau;
     }
     return F_driv;
 }
@@ -197,8 +197,8 @@ Point GeneralizedCentrifugalForceModel::ForceRepPed(
     Point F_rep;
     // x- and y-coordinate of the distance between p1 and p2
     Point distp12 = ped2.pos - ped1.pos;
-    const Point vp1 = (ped1.orientation * model1.speed); // v Ped1
-    const Point vp2 = (ped2.orientation * model2.speed); // v Ped2
+    const Point vp1 = (model1.orientation * model1.speed); // v Ped1
+    const Point vp2 = (model2.orientation * model2.speed); // v Ped2
     Point ep12; // x- and y-coordinate of the normalized vector between p1 and p2
     double tmp, tmp2;
     double v_ij;
@@ -342,8 +342,8 @@ GeneralizedCentrifugalForceModel::ForceRepWall(const GenericAgent& ped, const Li
     }
     double mind = 0.5; // for performance reasons this distance is assumed to be constant
     const auto& model = std::get<GeneralizedCentrifugalForceModelData>(ped.model);
-    double vn =
-        w.NormalComp(ped.orientation * model.speed); // normal component of the velocity on the wall
+    double vn = w.NormalComp(
+        model.orientation * model.speed); // normal component of the velocity on the wall
     F = ForceRepStatPoint(ped, pt, mind, vn);
 
     return F; // line --> l != 0
@@ -369,7 +369,7 @@ Point GeneralizedCentrifugalForceModel::ForceRepStatPoint(
     // TODO(kkratz): this will fail for speed 0.
     // I think the code can be rewritten to account for orientation and speed separately
     const auto& model = std::get<GeneralizedCentrifugalForceModelData>(ped.model);
-    const Point v = ped.orientation * model.speed;
+    const Point v = model.orientation * model.speed;
     Point dist = p - ped.pos; // x- and y-coordinate of the distance between ped and p
     double d = dist.Norm(); // distance between the centre of ped and point p
     Point e_ij; // x- and y-coordinate of the normalized vector between ped and p
@@ -392,10 +392,10 @@ Point GeneralizedCentrifugalForceModel::ForceRepStatPoint(
     double K_ij;
     K_ij = 0.5 * bla / v.Norm(); // K_ij
     // Punkt auf der Ellipse
-    pinE = p.TransformToEllipseCoordinates(ped.pos, ped.orientation.x, ped.orientation.y);
+    pinE = p.TransformToEllipseCoordinates(ped.pos, model.orientation.x, model.orientation.y);
     const auto v0 = model.v0;
     // Punkt auf der Ellipse
-    r = E.PointOnEllipse(pinE, model.speed / v0, ped.pos, model.speed, ped.orientation);
+    r = E.PointOnEllipse(pinE, model.speed / v0, ped.pos, model.speed, model.orientation);
     // interpolierte Kraft
     F_rep = ForceInterpolation(v0, K_ij, e_ij, vn, d, (r - ped.pos).Norm(), l);
     return F_rep;
@@ -480,6 +480,6 @@ double GeneralizedCentrifugalForceModel::AgentToAgentSpacing(
         scale2,
         model1.speed,
         model2.speed,
-        agent1.orientation,
-        agent2.orientation);
+        model1.orientation,
+        model2.orientation);
 }

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -98,7 +98,7 @@ void GeneralizedCentrifugalForceModel::CheckModelConstraint(
 {
     const auto& model = std::get<GeneralizedCentrifugalForceModelData>(agent.model);
 
-    if(!model.orientation.IsUnitLength(1e-9)) {
+    if(!model.orientation.IsUnitLength()) {
         throw SimulationError("Orientation is invalid: {}. Length should be 1.", model.orientation);
     }
 

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -10,6 +10,7 @@
 #include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Simulation.hpp"
+#include "SimulationError.hpp"
 
 #include <Logger.hpp>
 
@@ -96,6 +97,10 @@ void GeneralizedCentrifugalForceModel::CheckModelConstraint(
     const CollisionGeometry& geometry) const
 {
     const auto& model = std::get<GeneralizedCentrifugalForceModelData>(agent.model);
+
+    if(model.orientation.isZeroLength()) {
+        throw SimulationError("Orientation is invalid: {}. Length should be 1.", model.orientation);
+    }
 
     const auto mass = model.mass;
     constexpr double massMin = 1.;

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelData.hpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelData.hpp
@@ -5,7 +5,7 @@
 
 #include <fmt/core.h>
 struct GeneralizedCentrifugalForceModelData {
-    Point orientation{1.0, 0.0};
+    Point orientation{0.0, 0.0};
     double speed{};
     Point e0{};
     int orientationDelay{};

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelData.hpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelData.hpp
@@ -2,11 +2,10 @@
 #pragma once
 
 #include "Point.hpp"
-#include "SimulationError.hpp"
 
 #include <fmt/core.h>
 struct GeneralizedCentrifugalForceModelData {
-    Point orientation{0.0, 0.0};
+    Point orientation{1.0, 0.0};
     double speed{};
     Point e0{};
     int orientationDelay{};
@@ -17,36 +16,6 @@ struct GeneralizedCentrifugalForceModelData {
     double AMin{0.2};
     double BMin{0.2};
     double BMax{0.4};
-
-    GeneralizedCentrifugalForceModelData() =
-        default; // [RL, TODO] This does not make sense if we need the orientation to be normalized
-                 // to length 1.0
-    GeneralizedCentrifugalForceModelData(
-        Point orientation_,
-        double speed_,
-        Point e0_,
-        double mass_,
-        double tau_,
-        double v0_,
-        double Av_,
-        double AMin_,
-        double BMin_,
-        double BMax_)
-        : orientation(orientation_.Normalized())
-        , speed(speed_)
-        , e0(e0_)
-        , mass(mass_)
-        , tau(tau_)
-        , v0(v0_)
-        , Av(Av_)
-        , AMin(AMin_)
-        , BMin(BMin_)
-        , BMax(BMax_)
-    {
-        if(orientation.isZeroLength()) {
-            throw SimulationError("Orientation is invalid: {}. Length should be 1.", orientation);
-        }
-    }
 };
 
 template <>

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelData.hpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelData.hpp
@@ -2,9 +2,11 @@
 #pragma once
 
 #include "Point.hpp"
+#include "SimulationError.hpp"
 
 #include <fmt/core.h>
 struct GeneralizedCentrifugalForceModelData {
+    Point orientation{0.0, 0.0};
     double speed{};
     Point e0{};
     int orientationDelay{};
@@ -15,6 +17,36 @@ struct GeneralizedCentrifugalForceModelData {
     double AMin{0.2};
     double BMin{0.2};
     double BMax{0.4};
+
+    GeneralizedCentrifugalForceModelData() =
+        default; // [RL, TODO] This does not make sense if we need the orientation to be normalized
+                 // to length 1.0
+    GeneralizedCentrifugalForceModelData(
+        Point orientation_,
+        double speed_,
+        Point e0_,
+        double mass_,
+        double tau_,
+        double v0_,
+        double Av_,
+        double AMin_,
+        double BMin_,
+        double BMax_)
+        : orientation(orientation_.Normalized())
+        , speed(speed_)
+        , e0(e0_)
+        , mass(mass_)
+        , tau(tau_)
+        , v0(v0_)
+        , Av(Av_)
+        , AMin(AMin_)
+        , BMin(BMin_)
+        , BMax(BMax_)
+    {
+        if(orientation.isZeroLength()) {
+            throw SimulationError("Orientation is invalid: {}. Length should be 1.", orientation);
+        }
+    }
 };
 
 template <>
@@ -25,6 +57,6 @@ struct fmt::formatter<GeneralizedCentrifugalForceModelData> {
     template <typename FormatContext>
     auto format(const GeneralizedCentrifugalForceModelData& m, FormatContext& ctx) const
     {
-        return fmt::format_to(ctx.out(), "GCFM[speed={}])", m.speed);
+        return fmt::format_to(ctx.out(), "GCFM[orientation={}, speed={}])", m.orientation, m.speed);
     }
 };

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
@@ -65,7 +65,6 @@ void SocialForceModel::ApplyUpdate(const OperationalModelUpdate& update, Generic
     const auto& upd = std::get<SocialForceModelUpdate>(update);
     agent.pos = upd.position;
     model.velocity = upd.velocity;
-    agent.orientation = upd.velocity.Normalized();
 }
 
 void SocialForceModel::CheckModelConstraint(

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
@@ -354,7 +354,7 @@ void WarpDriverModel::ApplyUpdate(const OperationalModelUpdate& update, GenericA
     const auto& upd = std::get<WarpDriverModelUpdate>(update);
     auto& data = std::get<WarpDriverModelData>(agent.model);
     agent.pos = upd.position;
-    agent.orientation = upd.orientation;
+    data.orientation = upd.orientation;
     data.stuckTime = upd.stuckTime;
     data.anchorX = upd.anchorX;
     data.anchorY = upd.anchorY;
@@ -395,7 +395,7 @@ OperationalModelUpdate WarpDriverModel::ComputeNewPosition(
     const double speed = agentData.v0;
 
     // Agent orientation (unit vector). If zero, default to +x.
-    Point orient = ped.orientation;
+    Point orient = agentData.orientation;
     if(orient.Norm() < 1e-9) {
         orient = Point{1.0, 0.0};
     } else {
@@ -477,7 +477,7 @@ OperationalModelUpdate WarpDriverModel::ComputeNewPosition(
         }
 
         // Neighbor orientation
-        Point nbOrient = neighbor.orientation;
+        Point nbOrient = nbData->orientation;
         if(nbOrient.Norm() < 1e-9) {
             nbOrient = Point{1.0, 0.0};
         } else {

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelData.hpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelData.hpp
@@ -4,6 +4,7 @@
 #include <fmt/core.h>
 
 struct WarpDriverModelData {
+    Point orientation{0.0, 0.0};
     double radius{0.15};
     double v0{1.2};
     double stuckTime{0.0}; // elapsed time since anchor was set
@@ -11,6 +12,12 @@ struct WarpDriverModelData {
     double anchorY{0.0};
     double detourTime{0.0}; // remaining time in detour mode
     int detourSide{1}; // +1 = left, -1 = right of desired direction
+
+    WarpDriverModelData() = default;
+    WarpDriverModelData(Point orientation_, double radius_, double v0_)
+        : orientation(orientation_.Normalized()), radius(radius_), v0(v0_)
+    {
+    }
 };
 
 template <>
@@ -21,6 +28,11 @@ struct fmt::formatter<WarpDriverModelData> {
     template <typename FormatContext>
     auto format(const WarpDriverModelData& m, FormatContext& ctx) const
     {
-        return fmt::format_to(ctx.out(), "WarpDriver[radius={}, v0={}]", m.radius, m.v0);
+        return fmt::format_to(
+            ctx.out(),
+            "WarpDriver[orientation={}, radius={}, v0={}]",
+            m.orientation,
+            m.radius,
+            m.v0);
     }
 };

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelData.hpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelData.hpp
@@ -4,7 +4,7 @@
 #include <fmt/core.h>
 
 struct WarpDriverModelData {
-    Point orientation{0.0, 0.0};
+    Point orientation{1.0, 0.0};
     double radius{0.15};
     double v0{1.2};
     double stuckTime{0.0}; // elapsed time since anchor was set
@@ -12,12 +12,6 @@ struct WarpDriverModelData {
     double anchorY{0.0};
     double detourTime{0.0}; // remaining time in detour mode
     int detourSide{1}; // +1 = left, -1 = right of desired direction
-
-    WarpDriverModelData() = default;
-    WarpDriverModelData(Point orientation_, double radius_, double v0_)
-        : orientation(orientation_.Normalized()), radius(radius_), v0(v0_)
-    {
-    }
 };
 
 template <>

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelData.hpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelData.hpp
@@ -4,7 +4,7 @@
 #include <fmt/core.h>
 
 struct WarpDriverModelData {
-    Point orientation{1.0, 0.0};
+    Point orientation{0.0, 0.0};
     double radius{0.15};
     double v0{1.2};
     double stuckTime{0.0}; // elapsed time since anchor was set

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -3,8 +3,6 @@
 
 #include <Logger.hpp>
 
-#include <limits>
-
 bool Point::isZeroLength() const
 {
     constexpr double epsilon = 1e-6;
@@ -85,9 +83,9 @@ Point Point::Rotate90Deg() const
     return {-y, x};
 }
 
-bool Point::IsUnitLength() const
+bool Point::IsUnitLength(double tolerance) const
 {
-    return std::abs(1 - NormSquare()) <= std::numeric_limits<double>::epsilon();
+    return std::abs(1 - NormSquare()) <= tolerance;
 }
 
 const Point Point::operator+(const Point& p) const

--- a/libsimulator/src/Point.cpp
+++ b/libsimulator/src/Point.cpp
@@ -83,8 +83,9 @@ Point Point::Rotate90Deg() const
     return {-y, x};
 }
 
-bool Point::IsUnitLength(double tolerance) const
+bool Point::IsUnitLength() const
 {
+    constexpr double tolerance = 1e-9;
     return std::abs(1 - NormSquare()) <= tolerance;
 }
 

--- a/libsimulator/src/Point.hpp
+++ b/libsimulator/src/Point.hpp
@@ -51,7 +51,7 @@ public:
 
     /// Tests that the vector is length 1
     /// @return length == 1
-    bool IsUnitLength(double tolerance = std::numeric_limits<double>::epsilon()) const;
+    bool IsUnitLength() const;
 
     // operators
     /// addition

--- a/libsimulator/src/Point.hpp
+++ b/libsimulator/src/Point.hpp
@@ -4,6 +4,7 @@
 #include <fmt/core.h>
 #include <fmt/format.h>
 
+#include <limits>
 #include <tuple>
 
 class Point
@@ -50,7 +51,7 @@ public:
 
     /// Tests that the vector is length 1
     /// @return length == 1
-    bool IsUnitLength() const;
+    bool IsUnitLength(double tolerance = std::numeric_limits<double>::epsilon()) const;
 
     // operators
     /// addition

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -221,13 +221,6 @@ GenericAgent::ID Simulation::AddAgent(GenericAgent agent)
         throw SimulationError("Unknown stage id: {}", agent.stageId);
     }
 
-    if(std::holds_alternative<GeneralizedCentrifugalForceModelData>(agent.model))
-        if(agent.orientation.isZeroLength()) {
-            throw SimulationError(
-                "Orientation is invalid: {}. Length should be 1.", agent.orientation);
-        }
-
-    agent.orientation = agent.orientation.Normalized();
     _operationalDecisionSystem.ValidateAgent(agent, _neighborhoodSearch, *_geometry);
 
     _stageManager.HandleNewAgent(agent.stageId);

--- a/libsimulator/test/TestGenericAgentFormatter.cpp
+++ b/libsimulator/test/TestGenericAgentFormatter.cpp
@@ -11,7 +11,6 @@ static GenericAgent make_agent(GenericAgent::Model model)
         jps::UniqueID<Journey>::Invalid,
         jps::UniqueID<BaseStage>::Invalid,
         Point{1.0, 2.0},
-        Point{0.0, 1.0},
         std::move(model));
 }
 

--- a/libsimulator/test/TestStage.cpp
+++ b/libsimulator/test/TestStage.cpp
@@ -34,7 +34,6 @@ TEST_F(StagesTests, NotifiableWaitingSetTargetIsCorrect)
             Journey::ID::Invalid,
             waitingSet.Id(),
             waitingPoints[i],
-            {},
             CollisionFreeSpeedModelData{});
         neighborhoodSearch.AddAgent(agent);
 
@@ -50,7 +49,6 @@ TEST_F(StagesTests, NotifiableWaitingSetTargetIsCorrect)
             GenericAgent::ID::Invalid,
             Journey::ID::Invalid,
             waitingSet.Id(),
-            {},
             {},
             CollisionFreeSpeedModelData{});
         neighborhoodSearch.AddAgent(agentToLastWaitingSetPos);

--- a/notebooks/model-comparison.ipynb
+++ b/notebooks/model-comparison.ipynb
@@ -128,7 +128,7 @@
     "    journey_id = simulation.add_journey(journey)\n",
     "    centroids = [polygon.centroid.coords[0] for polygon in goals]\n",
     "    orientations = [\n",
-    "        np.array(centroid) - np.array(position)\n",
+    "        (v := np.array(centroid) - np.array(position)) / np.linalg.norm(v)\n",
     "        for centroid, position in zip(centroids, positions)\n",
     "    ]\n",
     "    for pos, v0, exit_id, orientation in zip(\n",

--- a/notebooks/model-comparison.ipynb
+++ b/notebooks/model-comparison.ipynb
@@ -152,7 +152,6 @@
     "                    stage_id=exit_id,\n",
     "                    desiredSpeed=v0,\n",
     "                    position=pos,\n",
-    "                    orientation=orientation,\n",
     "                )\n",
     "            )\n",
     "        elif (\n",

--- a/python_bindings_jupedsim/agent.cpp
+++ b/python_bindings_jupedsim/agent.cpp
@@ -20,21 +20,14 @@ void init_agent(py::module_& m)
             py::init([](uint64_t journeyId,
                         uint64_t stageId,
                         std::tuple<double, double> position,
-                        std::tuple<double, double> orientation,
                         GenericAgent::Model model) {
                 return GenericAgent(
-                    GenericAgent::ID::Invalid,
-                    journeyId,
-                    stageId,
-                    intoPoint(position),
-                    intoPoint(orientation),
-                    model);
+                    GenericAgent::ID::Invalid, journeyId, stageId, intoPoint(position), model);
             }),
             py::kw_only(),
             py::arg("journey_id"),
             py::arg("stage_id"),
             py::arg("position"),
-            py::arg("orientation"),
             py::arg("model"))
         .def_property_readonly("id", [](const GenericAgent& agent) { return agent.id.getID(); })
         .def_property_readonly(
@@ -43,8 +36,6 @@ void init_agent(py::module_& m)
             "stage_id", [](const GenericAgent& agent) { return agent.stageId.getID(); })
         .def_property_readonly(
             "position", [](const GenericAgent& agent) { return intoTuple(agent.pos); })
-        .def_property_readonly(
-            "orientation", [](const GenericAgent& agent) { return intoTuple(agent.orientation); })
         .def_property(
             "target",
             [](const GenericAgent& agent) { return intoTuple(agent.target); },

--- a/python_bindings_jupedsim/anticipation_velocity_model.cpp
+++ b/python_bindings_jupedsim/anticipation_velocity_model.cpp
@@ -4,6 +4,7 @@
 #include "AnticipationVelocityModelData.hpp"
 #include "OperationalModel.hpp"
 #include "conversion.hpp"
+#include "type_casters.hpp" // IWYU pragma: keep
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -35,15 +36,15 @@ void init_anticipation_velocity_model(py::module_& m)
                         double desiredSpeed,
                         double radius) {
                 return AnticipationVelocityModelData{
-                    intoPoint(orientation),
-                    strengthNeighborRepulsion,
-                    rangeNeighborRepulsion,
-                    wallBufferDistance,
-                    anticipationTime,
-                    reactionTime,
-                    timeGap,
-                    desiredSpeed,
-                    radius};
+                    .orientation = intoPoint(orientation),
+                    .strengthNeighborRepulsion = strengthNeighborRepulsion,
+                    .rangeNeighborRepulsion = rangeNeighborRepulsion,
+                    .wallBufferDistance = wallBufferDistance,
+                    .anticipationTime = anticipationTime,
+                    .reactionTime = reactionTime,
+                    .timeGap = timeGap,
+                    .v0 = desiredSpeed,
+                    .radius = radius};
             }),
             py::kw_only(),
             py::arg("orientation"),
@@ -55,9 +56,7 @@ void init_anticipation_velocity_model(py::module_& m)
             py::arg("time_gap"),
             py::arg("desired_speed"),
             py::arg("radius"))
-        .def_property_readonly(
-            "orientation",
-            [](const AnticipationVelocityModelData& obj) { return intoTuple(obj.orientation); })
+        .def_readwrite("orientation", &AnticipationVelocityModelData::orientation)
         .def_readwrite(
             "strength_neighbor_repulsion",
             &AnticipationVelocityModelData::strengthNeighborRepulsion)

--- a/python_bindings_jupedsim/anticipation_velocity_model.cpp
+++ b/python_bindings_jupedsim/anticipation_velocity_model.cpp
@@ -3,6 +3,7 @@
 #include "AnticipationVelocityModelBuilder.hpp"
 #include "AnticipationVelocityModelData.hpp"
 #include "OperationalModel.hpp"
+#include "conversion.hpp"
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -24,7 +25,8 @@ void init_anticipation_velocity_model(py::module_& m)
     py::class_<AnticipationVelocityModelData>(m, "AnticipationVelocityModelState")
         .def_static("_defaults", []() { return AnticipationVelocityModelData{}; })
         .def(
-            py::init([](double strengthNeighborRepulsion,
+            py::init([](std::tuple<double, double> orientation,
+                        double strengthNeighborRepulsion,
                         double rangeNeighborRepulsion,
                         double wallBufferDistance,
                         double anticipationTime,
@@ -33,16 +35,18 @@ void init_anticipation_velocity_model(py::module_& m)
                         double desiredSpeed,
                         double radius) {
                 return AnticipationVelocityModelData{
-                    .strengthNeighborRepulsion = strengthNeighborRepulsion,
-                    .rangeNeighborRepulsion = rangeNeighborRepulsion,
-                    .wallBufferDistance = wallBufferDistance,
-                    .anticipationTime = anticipationTime,
-                    .reactionTime = reactionTime,
-                    .timeGap = timeGap,
-                    .v0 = desiredSpeed,
-                    .radius = radius};
+                    intoPoint(orientation),
+                    strengthNeighborRepulsion,
+                    rangeNeighborRepulsion,
+                    wallBufferDistance,
+                    anticipationTime,
+                    reactionTime,
+                    timeGap,
+                    desiredSpeed,
+                    radius};
             }),
             py::kw_only(),
+            py::arg("orientation"),
             py::arg("strength_neighbor_repulsion"),
             py::arg("range_neighbor_repulsion"),
             py::arg("wall_buffer_distance"),
@@ -51,6 +55,9 @@ void init_anticipation_velocity_model(py::module_& m)
             py::arg("time_gap"),
             py::arg("desired_speed"),
             py::arg("radius"))
+        .def_property_readonly(
+            "orientation",
+            [](const AnticipationVelocityModelData& obj) { return intoTuple(obj.orientation); })
         .def_readwrite(
             "strength_neighbor_repulsion",
             &AnticipationVelocityModelData::strengthNeighborRepulsion)

--- a/python_bindings_jupedsim/collision_free_speed_model.cpp
+++ b/python_bindings_jupedsim/collision_free_speed_model.cpp
@@ -4,6 +4,7 @@
 #include "CollisionFreeSpeedModelData.hpp"
 #include "OperationalModel.hpp"
 #include "conversion.hpp"
+#include "type_casters.hpp" // IWYU pragma: keep
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -32,16 +33,17 @@ void init_collision_free_speed_model(py::module_& m)
                         double desiredSpeed,
                         double radius) {
                 return CollisionFreeSpeedModelData{
-                    intoPoint(orientation), timeGap, desiredSpeed, radius};
+                    .orientation = intoPoint(orientation),
+                    .timeGap = timeGap,
+                    .v0 = desiredSpeed,
+                    .radius = radius};
             }),
             py::kw_only(),
             py::arg("orientation"),
             py::arg("time_gap"),
             py::arg("desired_speed"),
             py::arg("radius"))
-        .def_property_readonly(
-            "orientation",
-            [](const CollisionFreeSpeedModelData& obj) { return intoTuple(obj.orientation); })
+        .def_readwrite("orientation", &CollisionFreeSpeedModelData::orientation)
         .def_readwrite("time_gap", &CollisionFreeSpeedModelData::timeGap)
         .def_readwrite("desired_speed", &CollisionFreeSpeedModelData::v0)
         .def_readwrite("radius", &CollisionFreeSpeedModelData::radius);

--- a/python_bindings_jupedsim/collision_free_speed_model.cpp
+++ b/python_bindings_jupedsim/collision_free_speed_model.cpp
@@ -3,6 +3,7 @@
 #include "CollisionFreeSpeedModelBuilder.hpp"
 #include "CollisionFreeSpeedModelData.hpp"
 #include "OperationalModel.hpp"
+#include "conversion.hpp"
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -26,14 +27,21 @@ void init_collision_free_speed_model(py::module_& m)
     py::class_<CollisionFreeSpeedModelData>(m, "CollisionFreeSpeedModelState")
         .def_static("_defaults", []() { return CollisionFreeSpeedModelData{}; })
         .def(
-            py::init([](double timeGap, double desiredSpeed, double radius) {
+            py::init([](std::tuple<double, double> orientation,
+                        double timeGap,
+                        double desiredSpeed,
+                        double radius) {
                 return CollisionFreeSpeedModelData{
-                    .timeGap = timeGap, .v0 = desiredSpeed, .radius = radius};
+                    intoPoint(orientation), timeGap, desiredSpeed, radius};
             }),
             py::kw_only(),
+            py::arg("orientation"),
             py::arg("time_gap"),
             py::arg("desired_speed"),
             py::arg("radius"))
+        .def_property_readonly(
+            "orientation",
+            [](const CollisionFreeSpeedModelData& obj) { return intoTuple(obj.orientation); })
         .def_readwrite("time_gap", &CollisionFreeSpeedModelData::timeGap)
         .def_readwrite("desired_speed", &CollisionFreeSpeedModelData::v0)
         .def_readwrite("radius", &CollisionFreeSpeedModelData::radius);

--- a/python_bindings_jupedsim/collision_free_speed_model_v2.cpp
+++ b/python_bindings_jupedsim/collision_free_speed_model_v2.cpp
@@ -3,6 +3,7 @@
 #include "CollisionFreeSpeedModelV2Builder.hpp"
 #include "CollisionFreeSpeedModelV2Data.hpp"
 #include "OperationalModel.hpp"
+#include "conversion.hpp"
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -21,7 +22,8 @@ void init_collision_free_speed_model_v2(py::module_& m)
     py::class_<CollisionFreeSpeedModelV2Data>(m, "CollisionFreeSpeedModelV2State")
         .def_static("_defaults", []() { return CollisionFreeSpeedModelV2Data{}; })
         .def(
-            py::init([](double strengthNeighborRepulsion,
+            py::init([](std::tuple<double, double> orientation,
+                        double strengthNeighborRepulsion,
                         double rangeNeighborRepulsion,
                         double strengthGeometryRepulsion,
                         double rangeGeometryRepulsion,
@@ -29,15 +31,17 @@ void init_collision_free_speed_model_v2(py::module_& m)
                         double desiredSpeed,
                         double radius) {
                 return CollisionFreeSpeedModelV2Data{
-                    .strengthNeighborRepulsion = strengthNeighborRepulsion,
-                    .rangeNeighborRepulsion = rangeNeighborRepulsion,
-                    .strengthGeometryRepulsion = strengthGeometryRepulsion,
-                    .rangeGeometryRepulsion = rangeGeometryRepulsion,
-                    .timeGap = timeGap,
-                    .v0 = desiredSpeed,
-                    .radius = radius};
+                    intoPoint(orientation),
+                    strengthNeighborRepulsion,
+                    rangeNeighborRepulsion,
+                    strengthGeometryRepulsion,
+                    rangeGeometryRepulsion,
+                    timeGap,
+                    desiredSpeed,
+                    radius};
             }),
             py::kw_only(),
+            py::arg("orientation"),
             py::arg("strength_neighbor_repulsion"),
             py::arg("range_neighbor_repulsion"),
             py::arg("strength_geometry_repulsion"),
@@ -45,6 +49,9 @@ void init_collision_free_speed_model_v2(py::module_& m)
             py::arg("time_gap"),
             py::arg("desired_speed"),
             py::arg("radius"))
+        .def_property_readonly(
+            "orientation",
+            [](const CollisionFreeSpeedModelV2Data& obj) { return intoTuple(obj.orientation); })
         .def_readwrite(
             "strength_neighbor_repulsion",
             &CollisionFreeSpeedModelV2Data::strengthNeighborRepulsion)

--- a/python_bindings_jupedsim/collision_free_speed_model_v2.cpp
+++ b/python_bindings_jupedsim/collision_free_speed_model_v2.cpp
@@ -4,6 +4,7 @@
 #include "CollisionFreeSpeedModelV2Data.hpp"
 #include "OperationalModel.hpp"
 #include "conversion.hpp"
+#include "type_casters.hpp" // IWYU pragma: keep
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -31,14 +32,14 @@ void init_collision_free_speed_model_v2(py::module_& m)
                         double desiredSpeed,
                         double radius) {
                 return CollisionFreeSpeedModelV2Data{
-                    intoPoint(orientation),
-                    strengthNeighborRepulsion,
-                    rangeNeighborRepulsion,
-                    strengthGeometryRepulsion,
-                    rangeGeometryRepulsion,
-                    timeGap,
-                    desiredSpeed,
-                    radius};
+                    .orientation = intoPoint(orientation),
+                    .strengthNeighborRepulsion = strengthNeighborRepulsion,
+                    .rangeNeighborRepulsion = rangeNeighborRepulsion,
+                    .strengthGeometryRepulsion = strengthGeometryRepulsion,
+                    .rangeGeometryRepulsion = rangeGeometryRepulsion,
+                    .timeGap = timeGap,
+                    .v0 = desiredSpeed,
+                    .radius = radius};
             }),
             py::kw_only(),
             py::arg("orientation"),
@@ -49,9 +50,7 @@ void init_collision_free_speed_model_v2(py::module_& m)
             py::arg("time_gap"),
             py::arg("desired_speed"),
             py::arg("radius"))
-        .def_property_readonly(
-            "orientation",
-            [](const CollisionFreeSpeedModelV2Data& obj) { return intoTuple(obj.orientation); })
+        .def_readwrite("orientation", &CollisionFreeSpeedModelV2Data::orientation)
         .def_readwrite(
             "strength_neighbor_repulsion",
             &CollisionFreeSpeedModelV2Data::strengthNeighborRepulsion)

--- a/python_bindings_jupedsim/collision_free_speed_model_v3.cpp
+++ b/python_bindings_jupedsim/collision_free_speed_model_v3.cpp
@@ -3,6 +3,7 @@
 #include "CollisionFreeSpeedModelV3Builder.hpp"
 #include "CollisionFreeSpeedModelV3Data.hpp"
 #include "OperationalModel.hpp"
+#include "conversion.hpp"
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -20,7 +21,8 @@ void init_collision_free_speed_model_v3(py::module_& m)
 
     py::class_<CollisionFreeSpeedModelV3Data>(m, "CollisionFreeSpeedModelV3State")
         .def(
-            py::init([](double strengthNeighborRepulsion,
+            py::init([](std::tuple<double, double> orientation,
+                        double strengthNeighborRepulsion,
                         double rangeNeighborRepulsion,
                         double strengthGeometryRepulsion,
                         double rangeGeometryRepulsion,
@@ -32,19 +34,21 @@ void init_collision_free_speed_model_v3(py::module_& m)
                         double thetaMaxUpperBound,
                         double agentBuffer) {
                 return CollisionFreeSpeedModelV3Data{
-                    .strengthNeighborRepulsion = strengthNeighborRepulsion,
-                    .rangeNeighborRepulsion = rangeNeighborRepulsion,
-                    .strengthGeometryRepulsion = strengthGeometryRepulsion,
-                    .rangeGeometryRepulsion = rangeGeometryRepulsion,
-                    .rangeXScale = rangeXScale,
-                    .rangeYScale = rangeYScale,
-                    .thetaMaxUpperBound = thetaMaxUpperBound,
-                    .agentBuffer = agentBuffer,
-                    .timeGap = timeGap,
-                    .v0 = desiredSpeed,
-                    .radius = radius};
+                    intoPoint(orientation),
+                    strengthNeighborRepulsion,
+                    rangeNeighborRepulsion,
+                    strengthGeometryRepulsion,
+                    rangeGeometryRepulsion,
+                    rangeXScale,
+                    rangeYScale,
+                    thetaMaxUpperBound,
+                    agentBuffer,
+                    timeGap,
+                    desiredSpeed,
+                    radius};
             }),
             py::kw_only(),
+            py::arg("orientation"),
             py::arg("strength_neighbor_repulsion"),
             py::arg("range_neighbor_repulsion"),
             py::arg("strength_geometry_repulsion"),
@@ -56,6 +60,9 @@ void init_collision_free_speed_model_v3(py::module_& m)
             py::arg("range_y_scale") = 8.0,
             py::arg("theta_max_upper_bound") = 1.57,
             py::arg("agent_buffer") = 0.0)
+        .def_property_readonly(
+            "orientation",
+            [](const CollisionFreeSpeedModelV3Data& obj) { return intoTuple(obj.orientation); })
         .def_readwrite(
             "strength_neighbor_repulsion",
             &CollisionFreeSpeedModelV3Data::strengthNeighborRepulsion)

--- a/python_bindings_jupedsim/collision_free_speed_model_v3.cpp
+++ b/python_bindings_jupedsim/collision_free_speed_model_v3.cpp
@@ -4,6 +4,7 @@
 #include "CollisionFreeSpeedModelV3Data.hpp"
 #include "OperationalModel.hpp"
 #include "conversion.hpp"
+#include "type_casters.hpp" // IWYU pragma: keep
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -34,18 +35,18 @@ void init_collision_free_speed_model_v3(py::module_& m)
                         double thetaMaxUpperBound,
                         double agentBuffer) {
                 return CollisionFreeSpeedModelV3Data{
-                    intoPoint(orientation),
-                    strengthNeighborRepulsion,
-                    rangeNeighborRepulsion,
-                    strengthGeometryRepulsion,
-                    rangeGeometryRepulsion,
-                    rangeXScale,
-                    rangeYScale,
-                    thetaMaxUpperBound,
-                    agentBuffer,
-                    timeGap,
-                    desiredSpeed,
-                    radius};
+                    .orientation = intoPoint(orientation),
+                    .strengthNeighborRepulsion = strengthNeighborRepulsion,
+                    .rangeNeighborRepulsion = rangeNeighborRepulsion,
+                    .strengthGeometryRepulsion = strengthGeometryRepulsion,
+                    .rangeGeometryRepulsion = rangeGeometryRepulsion,
+                    .rangeXScale = rangeXScale,
+                    .rangeYScale = rangeYScale,
+                    .thetaMaxUpperBound = thetaMaxUpperBound,
+                    .agentBuffer = agentBuffer,
+                    .timeGap = timeGap,
+                    .v0 = desiredSpeed,
+                    .radius = radius};
             }),
             py::kw_only(),
             py::arg("orientation"),
@@ -60,9 +61,7 @@ void init_collision_free_speed_model_v3(py::module_& m)
             py::arg("range_y_scale") = 8.0,
             py::arg("theta_max_upper_bound") = 1.57,
             py::arg("agent_buffer") = 0.0)
-        .def_property_readonly(
-            "orientation",
-            [](const CollisionFreeSpeedModelV3Data& obj) { return intoTuple(obj.orientation); })
+        .def_readwrite("orientation", &CollisionFreeSpeedModelV3Data::orientation)
         .def_readwrite(
             "strength_neighbor_repulsion",
             &CollisionFreeSpeedModelV3Data::strengthNeighborRepulsion)

--- a/python_bindings_jupedsim/generalized_centrifugal_force_model.cpp
+++ b/python_bindings_jupedsim/generalized_centrifugal_force_model.cpp
@@ -35,7 +35,8 @@ void init_generalized_centrifugal_force_model(py::module_& m)
     py::class_<GeneralizedCentrifugalForceModelData>(m, "GeneralizedCentrifugalForceModelState")
         .def_static("_defaults", []() { return GeneralizedCentrifugalForceModelData{}; })
         .def(
-            py::init([](double speed,
+            py::init([](std::tuple<double, double> orientation,
+                        double speed,
                         std::tuple<double, double> desiredOrientation,
                         double mass,
                         double tau,
@@ -45,17 +46,19 @@ void init_generalized_centrifugal_force_model(py::module_& m)
                         double bmin,
                         double bmax) {
                 return GeneralizedCentrifugalForceModelData{
-                    .speed = speed,
-                    .e0 = intoPoint(desiredOrientation),
-                    .mass = mass,
-                    .tau = tau,
-                    .v0 = desiredSpeed,
-                    .Av = av,
-                    .AMin = amin,
-                    .BMin = bmin,
-                    .BMax = bmax};
+                    intoPoint(orientation),
+                    speed,
+                    intoPoint(desiredOrientation),
+                    mass,
+                    tau,
+                    desiredSpeed,
+                    av,
+                    amin,
+                    bmin,
+                    bmax};
             }),
             py::kw_only(),
+            py::arg("orientation"),
             py::arg("speed"),
             py::arg("desired_direction"),
             py::arg("mass"),
@@ -65,6 +68,11 @@ void init_generalized_centrifugal_force_model(py::module_& m)
             py::arg("a_min"),
             py::arg("b_min"),
             py::arg("b_max"))
+        .def_property_readonly(
+            "orientation",
+            [](const GeneralizedCentrifugalForceModelData& obj) {
+                return intoTuple(obj.orientation);
+            })
         .def_readwrite("speed", &GeneralizedCentrifugalForceModelData::speed)
         .def_property(
             "desired_direction",

--- a/python_bindings_jupedsim/generalized_centrifugal_force_model.cpp
+++ b/python_bindings_jupedsim/generalized_centrifugal_force_model.cpp
@@ -4,6 +4,7 @@
 #include "GeneralizedCentrifugalForceModelData.hpp"
 #include "OperationalModel.hpp"
 #include "conversion.hpp"
+#include "type_casters.hpp" // IWYU pragma: keep
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -46,16 +47,16 @@ void init_generalized_centrifugal_force_model(py::module_& m)
                         double bmin,
                         double bmax) {
                 return GeneralizedCentrifugalForceModelData{
-                    intoPoint(orientation),
-                    speed,
-                    intoPoint(desiredOrientation),
-                    mass,
-                    tau,
-                    desiredSpeed,
-                    av,
-                    amin,
-                    bmin,
-                    bmax};
+                    .orientation = intoPoint(orientation),
+                    .speed = speed,
+                    .e0 = intoPoint(desiredOrientation),
+                    .mass = mass,
+                    .tau = tau,
+                    .v0 = desiredSpeed,
+                    .Av = av,
+                    .AMin = amin,
+                    .BMin = bmin,
+                    .BMax = bmax};
             }),
             py::kw_only(),
             py::arg("orientation"),
@@ -68,11 +69,7 @@ void init_generalized_centrifugal_force_model(py::module_& m)
             py::arg("a_min"),
             py::arg("b_min"),
             py::arg("b_max"))
-        .def_property_readonly(
-            "orientation",
-            [](const GeneralizedCentrifugalForceModelData& obj) {
-                return intoTuple(obj.orientation);
-            })
+        .def_readwrite("orientation", &GeneralizedCentrifugalForceModelData::orientation)
         .def_readwrite("speed", &GeneralizedCentrifugalForceModelData::speed)
         .def_property(
             "desired_direction",

--- a/python_bindings_jupedsim/geometry.cpp
+++ b/python_bindings_jupedsim/geometry.cpp
@@ -2,7 +2,7 @@
 #include "CollisionGeometry.hpp"
 #include "GeometryBuilder.hpp"
 #include "conversion.hpp"
-#include "type_casters.hpp"
+#include "type_casters.hpp" // IWYU pragma: keep
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h> // IWYU pragma: keep

--- a/python_bindings_jupedsim/geometry.cpp
+++ b/python_bindings_jupedsim/geometry.cpp
@@ -2,6 +2,7 @@
 #include "CollisionGeometry.hpp"
 #include "GeometryBuilder.hpp"
 #include "conversion.hpp"
+#include "type_casters.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h> // IWYU pragma: keep

--- a/python_bindings_jupedsim/social_force_model.cpp
+++ b/python_bindings_jupedsim/social_force_model.cpp
@@ -49,6 +49,9 @@ void init_social_force_model(py::module_& m)
             py::arg("obstacle_scale"),
             py::arg("force_distance"),
             py::arg("radius"))
+        .def_property_readonly(
+            "orientation",
+            [](const SocialForceModelData& obj) { return intoTuple(obj.velocity.Normalized()); })
         .def_property(
             "velocity",
             [](const SocialForceModelData& obj) { return intoTuple(obj.velocity); },

--- a/python_bindings_jupedsim/warp_driver_model.cpp
+++ b/python_bindings_jupedsim/warp_driver_model.cpp
@@ -4,6 +4,7 @@
 #include "WarpDriverModelBuilder.hpp"
 #include "WarpDriverModelData.hpp"
 #include "conversion.hpp"
+#include "type_casters.hpp" // IWYU pragma: keep
 
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
@@ -32,15 +33,14 @@ void init_warp_driver_model(py::module_& m)
             py::init([](std::tuple<double, double> orientation,
                         double desired_speed,
                         double radius) {
-                return WarpDriverModelData{intoPoint(orientation), radius, desired_speed};
+                return WarpDriverModelData{
+                    .orientation = intoPoint(orientation), .radius = radius, .v0 = desired_speed};
             }),
             py::kw_only(),
             py::arg("orientation"),
             py::arg("desired_speed") = 1.2,
             py::arg("radius") = 0.15)
-        .def_property_readonly(
-            "orientation",
-            [](const WarpDriverModelData& obj) { return intoTuple(obj.orientation); })
+        .def_readwrite("orientation", &WarpDriverModelData::orientation)
         .def_readwrite("radius", &WarpDriverModelData::radius)
         .def_readwrite("desired_speed", &WarpDriverModelData::v0);
 }

--- a/python_bindings_jupedsim/warp_driver_model.cpp
+++ b/python_bindings_jupedsim/warp_driver_model.cpp
@@ -3,8 +3,13 @@
 #include "WarpDriverModel.hpp"
 #include "WarpDriverModelBuilder.hpp"
 #include "WarpDriverModelData.hpp"
+#include "conversion.hpp"
 
+#include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h> // IWYU pragma: keep
+
+#include <tuple>
 
 namespace py = pybind11;
 
@@ -24,12 +29,18 @@ void init_warp_driver_model(py::module_& m)
         .def("build", &WarpDriverModelBuilder::Build);
     py::class_<WarpDriverModelData>(m, "WarpDriverModelState")
         .def(
-            py::init([](double desired_speed, double radius) {
-                return WarpDriverModelData{.radius = radius, .v0 = desired_speed};
+            py::init([](std::tuple<double, double> orientation,
+                        double desired_speed,
+                        double radius) {
+                return WarpDriverModelData{intoPoint(orientation), radius, desired_speed};
             }),
             py::kw_only(),
+            py::arg("orientation"),
             py::arg("desired_speed") = 1.2,
             py::arg("radius") = 0.15)
+        .def_property_readonly(
+            "orientation",
+            [](const WarpDriverModelData& obj) { return intoTuple(obj.orientation); })
         .def_readwrite("radius", &WarpDriverModelData::radius)
         .def_readwrite("desired_speed", &WarpDriverModelData::v0);
 }

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -76,7 +76,7 @@ class Agent:
     @property
     def orientation(self) -> tuple[float, float]:
         """Orientation of the agent."""
-        return self._obj.orientation
+        return self._obj.model.orientation
 
     @property
     def target(self) -> tuple[float, float]:

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -74,11 +74,6 @@ class Agent:
         return self._obj.position
 
     @property
-    def orientation(self) -> tuple[float, float]:
-        """Orientation of the agent."""
-        return self._obj.model.orientation
-
-    @property
     def target(self) -> tuple[float, float]:
         """Current target of the agent.
 

--- a/python_modules/jupedsim/jupedsim/hdf5_serialization.py
+++ b/python_modules/jupedsim/jupedsim/hdf5_serialization.py
@@ -34,7 +34,7 @@ except ImportError as e:  # pragma: no cover - dependency is optional
     ) from e
 
 
-SCHEMA_VERSION: Final = 1
+SCHEMA_VERSION: Final = 2
 
 
 def _trajectory_dtype() -> "np.dtype":
@@ -43,8 +43,7 @@ def _trajectory_dtype() -> "np.dtype":
     The leading four columns (``frame``, ``id``, ``x``, ``y``) match the
     Pedestrian Dynamics Data Archive convention used by PedPy's loader.
     ``z`` is included for byte-level compatibility with the archive
-    format and is always written as ``0.0`` (planar simulation). The
-    orientation columns are JuPedSim-specific extras.
+    format and is always written as ``0.0`` (planar simulation).
     """
     return np.dtype(
         [
@@ -53,8 +52,6 @@ def _trajectory_dtype() -> "np.dtype":
             ("x", "<f8"),
             ("y", "<f8"),
             ("z", "<f8"),
-            ("ox", "<f8"),
-            ("oy", "<f8"),
         ]
     )
 
@@ -78,8 +75,8 @@ class Hdf5TrajectoryWriter(TrajectoryWriter):
 
     - ``/trajectory`` -- compound, resizable dataset with one row per
       agent per recorded frame. Columns: ``frame``, ``id``, ``x``,
-      ``y``, ``z``, ``ox``, ``oy``. Carries an ``fps`` attribute (the
-      attribute PedPy reads).
+      ``y``, ``z``. Carries an ``fps`` attribute (the attribute PedPy
+      reads).
     - Root attribute ``wkt_geometry`` -- the initial walkable area as
       WKT (the attribute PedPy reads).
     - Additional root attributes describing the producer, schema
@@ -194,8 +191,6 @@ class Hdf5TrajectoryWriter(TrajectoryWriter):
                 "x": "m",
                 "y": "m",
                 "z": "m",
-                "ox": "-",
-                "oy": "-",
             }
         )
         self._traj_ds.attrs["column_descriptions"] = json.dumps(
@@ -205,8 +200,6 @@ class Hdf5TrajectoryWriter(TrajectoryWriter):
                 "x": "position (x)",
                 "y": "position (y)",
                 "z": "position (z), always 0 for planar simulations",
-                "ox": "orientation unit vector (x)",
-                "oy": "orientation unit vector (y)",
             }
         )
 
@@ -246,8 +239,6 @@ class Hdf5TrajectoryWriter(TrajectoryWriter):
                     agent.position[0],
                     agent.position[1],
                     0.0,
-                    agent.orientation[0],
-                    agent.orientation[1],
                 )
             )
 

--- a/python_modules/jupedsim/jupedsim/internal/notebook_utils.py
+++ b/python_modules/jupedsim/jupedsim/internal/notebook_utils.py
@@ -28,7 +28,7 @@ def read_sqlite_file(
     """ """
     with sqlite3.connect(trajectory_file) as con:
         data = pd.read_sql_query(
-            "select frame, id, pos_x as x, pos_y as y, ori_x as ox, ori_y as oy from trajectory_data",
+            "select frame, id, pos_x as x, pos_y as y from trajectory_data",
             con,
         )
         fps = float(
@@ -59,8 +59,16 @@ def _get_line_color(disk_color):
 
 
 def _create_orientation_line(row, line_length=0.2, color="black"):
-    end_x = row["x"] + line_length * row["ox"]
-    end_y = row["y"] + line_length * row["oy"]
+    # Derive the orientation from the pedpy-computed velocity (v_x, v_y).
+    vx = row["v_x"]
+    vy = row["v_y"]
+    norm = np.hypot(vx, vy)
+    if norm > 0:
+        vx, vy = vx / norm, vy / norm
+    else:
+        vx = vy = 0.0
+    end_x = row["x"] + line_length * vx
+    end_y = row["y"] + line_length * vy
 
     orientation_line = go.layout.Shape(
         type="line",
@@ -306,6 +314,7 @@ def animate(
     data_df = pedpy.compute_individual_speed(
         traj_data=data,
         frame_step=5,
+        compute_velocity=True,
         speed_calculation=pedpy.SpeedCalculation.BORDER_SINGLE_SIDED,
     )
     data_df = data_df.merge(data.data, on=["id", "frame"], how="left")

--- a/python_modules/jupedsim/jupedsim/models/anticipation_velocity_model.py
+++ b/python_modules/jupedsim/jupedsim/models/anticipation_velocity_model.py
@@ -64,6 +64,7 @@ class AnticipationVelocityModelAgentParameters:
 
     Attributes:
         position: Position of the agent.
+        orientation: Orientation of the agent.
         time_gap: Time constant that describe how fast pedestrian close gaps.
         desired_speed: Maximum speed of the agent.
         radius: Radius of the agent.
@@ -77,6 +78,7 @@ class AnticipationVelocityModelAgentParameters:
     """
 
     position: tuple[float, float] = (0.0, 0.0)
+    orientation: tuple[float, float] = (0.0, 0.0)
     time_gap: float = 1.06
     desired_speed: float = 1.2
     radius: float = 0.2

--- a/python_modules/jupedsim/jupedsim/models/anticipation_velocity_model.py
+++ b/python_modules/jupedsim/jupedsim/models/anticipation_velocity_model.py
@@ -96,6 +96,15 @@ class AnticipationVelocityModelState:
         self._obj = backing
 
     @property
+    def orientation(self) -> tuple[float, float]:
+        """Orientation of this agent."""
+        return self._obj.orientation
+
+    @orientation.setter
+    def orientation(self, orientation):
+        self._obj.orientation = orientation
+
+    @property
     def time_gap(self) -> float:
         return self._obj.time_gap
 

--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed.py
@@ -56,6 +56,7 @@ class CollisionFreeSpeedModelAgentParameters:
 
     Attributes:
         position: Position of the agent.
+        orientation: Orientation of the agent.
         time_gap: Time constant that describe how fast pedestrian close gaps.
         desired_speed: Maximum speed of the agent.
         radius: Radius of the agent.
@@ -64,6 +65,7 @@ class CollisionFreeSpeedModelAgentParameters:
     """
 
     position: tuple[float, float] = (0.0, 0.0)
+    orientation: tuple[float, float] = (0.0, 0.0)
     time_gap: float = 1.0
     desired_speed: float = 1.2
     radius: float = 0.2
@@ -74,6 +76,7 @@ class CollisionFreeSpeedModelAgentParameters:
         self,
         *,
         position: tuple[float, float] = (0.0, 0.0),
+        orientation: tuple[float, float] = (0.0, 0.0),
         time_gap: float = 1.0,
         desired_speed: float = 1.2,
         radius: float = 0.2,
@@ -82,6 +85,7 @@ class CollisionFreeSpeedModelAgentParameters:
         v0: float | None = None,
     ):
         self.position = position
+        self.orientation = orientation
         self.time_gap = time_gap
         if v0 is not None:
             warnings.warn(

--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed.py
@@ -116,6 +116,15 @@ class CollisionFreeSpeedModelState:
         self._obj = backing
 
     @property
+    def orientation(self) -> tuple[float, float]:
+        """Orientation of this agent."""
+        return self._obj.orientation
+
+    @orientation.setter
+    def orientation(self, orientation):
+        self._obj.orientation = orientation
+
+    @property
     def time_gap(self) -> float:
         return self._obj.time_gap
 

--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed_v2.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed_v2.py
@@ -126,6 +126,15 @@ class CollisionFreeSpeedModelV2State:
         self._obj = backing
 
     @property
+    def orientation(self) -> tuple[float, float]:
+        """Orientation of this agent."""
+        return self._obj.orientation
+
+    @orientation.setter
+    def orientation(self, orientation):
+        self._obj.orientation = orientation
+
+    @property
     def time_gap(self) -> float:
         return self._obj.time_gap
 

--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed_v2.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed_v2.py
@@ -50,6 +50,7 @@ class CollisionFreeSpeedModelV2AgentParameters:
 
     Attributes:
         position: Position of the agent.
+        orientation: Orientation of the agent.
         time_gap: Time constant that describe how fast pedestrian close gaps.
         desired_speed: Maximum speed of the agent.
         radius: Radius of the agent.
@@ -62,6 +63,7 @@ class CollisionFreeSpeedModelV2AgentParameters:
     """
 
     position: tuple[float, float] = (0.0, 0.0)
+    orientation: tuple[float, float] = (0.0, 0.0)
     time_gap: float = 1.0
     desired_speed: float = 1.2
     radius: float = 0.2
@@ -76,6 +78,7 @@ class CollisionFreeSpeedModelV2AgentParameters:
         self,
         *,
         position: tuple[float, float] = (0.0, 0.0),
+        orientation: tuple[float, float] = (0.0, 0.0),
         time_gap: float = 1.0,
         desired_speed: float = 1.2,
         v0: float | None = None,
@@ -88,6 +91,7 @@ class CollisionFreeSpeedModelV2AgentParameters:
         range_geometry_repulsion: float = 0.02,
     ):
         self.position = position
+        self.orientation = orientation
         self.time_gap = time_gap
         if v0 is not None:
             warnings.warn(

--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed_v3.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed_v3.py
@@ -153,6 +153,15 @@ class CollisionFreeSpeedModelV3State:
         self._obj = backing
 
     @property
+    def orientation(self) -> tuple[float, float]:
+        """Orientation of this agent."""
+        return self._obj.orientation
+
+    @orientation.setter
+    def orientation(self, orientation):
+        self._obj.orientation = orientation
+
+    @property
     def time_gap(self) -> float:
         return self._obj.time_gap
 

--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed_v3.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed_v3.py
@@ -49,6 +49,7 @@ class CollisionFreeSpeedModelV3AgentParameters:
 
     Attributes:
         position: Position of the agent.
+        orientation: Orientation of the agent.
         time_gap: Time constant that describes how fast a pedestrian closes gaps.
         desired_speed: Maximum (free) walking speed of the agent.
         radius: Radius of the agent.
@@ -72,6 +73,7 @@ class CollisionFreeSpeedModelV3AgentParameters:
     """
 
     position: tuple[float, float] = (0.0, 0.0)
+    orientation: tuple[float, float] = (0.0, 0.0)
     time_gap: float = 1.0
     desired_speed: float = 1.2
     radius: float = 0.2
@@ -92,6 +94,7 @@ class CollisionFreeSpeedModelV3AgentParameters:
         self,
         *,
         position: tuple[float, float] = (0.0, 0.0),
+        orientation: tuple[float, float] = (0.0, 0.0),
         time_gap: float = 1.0,
         desired_speed: float = 1.2,
         v0: float | None = None,
@@ -108,6 +111,7 @@ class CollisionFreeSpeedModelV3AgentParameters:
         agent_buffer: float = 0.0,
     ):
         self.position = position
+        self.orientation = orientation
         self.time_gap = time_gap
         if v0 is not None:
             warnings.warn(

--- a/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
+++ b/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
@@ -63,7 +63,7 @@ class GeneralizedCentrifugalForceModelAgentParameters:
         speed: Speed of the agent.
         desired_direction: Desired direction of the agent.
         position: Position of the agent.
-        orientation: Orientation of the agent.
+        orientation: Orientation of the agent. Has to be normalized to length 1.0
         journey_id: Id of the journey the agent follows.
         stage_id: Id of the stage the agent targets.
         mass: Mass of the agent.

--- a/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
+++ b/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
@@ -187,6 +187,15 @@ class GeneralizedCentrifugalForceModelState:
         self._obj.desired_direction = e0
 
     @property
+    def orientation(self) -> tuple[float, float]:
+        """Orientation of this agent."""
+        return self._obj.orientation
+
+    @orientation.setter
+    def orientation(self, orientation):
+        self._obj.orientation = orientation
+
+    @property
     def tau(self) -> float:
         return self._obj.tau
 

--- a/python_modules/jupedsim/jupedsim/models/social_force.py
+++ b/python_modules/jupedsim/jupedsim/models/social_force.py
@@ -68,7 +68,6 @@ class SocialForceModelAgentParameters:
 
     Attributes:
         position: Position of the agent.
-        orientation: Orientation of the agent.
         journey_id: Id of the journey the agent follows.
         stage_id: Id of the stage the agent targets.
         velocity: current velocity of the agent.
@@ -83,7 +82,6 @@ class SocialForceModelAgentParameters:
 
     # todo write force equation from paper
     position: tuple[float, float] = (0.0, 0.0)
-    orientation: tuple[float, float] = (0.0, 0.0)
     journey_id: int = -1
     stage_id: int = -1
     velocity: tuple[float, float] = (0.0, 0.0)
@@ -103,7 +101,6 @@ class SocialForceModelAgentParameters:
     def __init__(
         self,
         position: tuple[float, float] = (0.0, 0.0),
-        orientation: tuple[float, float] = (0.0, 0.0),
         journey_id: int = -1,
         stage_id: int = -1,
         velocity: tuple[float, float] = (0.0, 0.0),
@@ -122,7 +119,6 @@ class SocialForceModelAgentParameters:
     ):
         """Init dataclass to handle deprecated arguments."""
         self.position = position
-        self.orientation = orientation
         self.journey_id = journey_id
         self.stage_id = stage_id
         self.velocity = velocity

--- a/python_modules/jupedsim/jupedsim/models/warp_driver.py
+++ b/python_modules/jupedsim/jupedsim/models/warp_driver.py
@@ -55,6 +55,15 @@ class WarpDriverModelState:
         self._obj = backing
 
     @property
+    def orientation(self) -> tuple[float, float]:
+        """Orientation of this agent."""
+        return self._obj.orientation
+
+    @orientation.setter
+    def orientation(self, orientation):
+        self._obj.orientation = orientation
+
+    @property
     def radius(self) -> float:
         """Radius of this agent [m]."""
         return self._obj.radius

--- a/python_modules/jupedsim/jupedsim/recording.py
+++ b/python_modules/jupedsim/jupedsim/recording.py
@@ -14,7 +14,6 @@ class RecordingAgent:
 
     id: int
     position: tuple[float, float]
-    orientation: tuple[float, float]
 
 
 @dataclass
@@ -26,7 +25,7 @@ class RecordingFrame:
 
 
 class Recording:
-    __supported_database_version = 2
+    __supported_database_version = 3
     """Provides access to a simulation recording in a sqlite database"""
 
     def __init__(self, db_connection_str: str, uri=False) -> None:
@@ -48,12 +47,12 @@ class Recording:
         """
 
         def agent_row(cursor, row):
-            return RecordingAgent(row[0], (row[1], row[2]), (row[3], row[4]))
+            return RecordingAgent(row[0], (row[1], row[2]))
 
         cur = self.db.cursor()
         cur.row_factory = agent_row
         res = cur.execute(
-            "SELECT id, pos_x, pos_y, ori_x, ori_y FROM trajectory_data WHERE frame == (?) ORDER BY id ASC",
+            "SELECT id, pos_x, pos_y FROM trajectory_data WHERE frame == (?) ORDER BY id ASC",
             (index,),
         )
         return RecordingFrame(index, res.fetchall())
@@ -79,16 +78,24 @@ class Recording:
         return res.fetchone()[0]
 
     def bounds(self) -> AABB:
-        """Get bounds of the position data contained in this recording."""
         cur = self.db.cursor()
-        res = cur.execute("SELECT value FROM metadata WHERE key == 'xmin'")
-        xmin = float(res.fetchone()[0])
-        res = cur.execute("SELECT value FROM metadata WHERE key == 'xmax'")
-        xmax = float(res.fetchone()[0])
-        res = cur.execute("SELECT value FROM metadata WHERE key == 'ymin'")
-        ymin = float(res.fetchone()[0])
-        res = cur.execute("SELECT value FROM metadata WHERE key == 'ymax'")
-        ymax = float(res.fetchone()[0])
+
+        def get_float_or_none(key):
+            res = cur.execute(
+                f"SELECT value FROM metadata WHERE key == '{key}'"
+            ).fetchone()
+            return float(res[0]) if res else None
+
+        xmin = get_float_or_none("xmin")
+        xmax = get_float_or_none("xmax")
+        ymin = get_float_or_none("ymin")
+        ymax = get_float_or_none("ymax")
+
+        if None in (xmin, xmax, ymin, ymax):
+            raise Exception(
+                "Recording has no position bounds metadata. It is likely empty."
+            )
+
         return AABB(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
 
     @property

--- a/python_modules/jupedsim/jupedsim/simulation.py
+++ b/python_modules/jupedsim/jupedsim/simulation.py
@@ -300,10 +300,6 @@ class Simulation:
                 Id of the added agent.
         """
 
-        # Helper function to allow not passing orientation to models not requiring it.
-        def orientation_or_zero(param):
-            return getattr(param, "orientation", (0.0, 0.0))
-
         if isinstance(
             parameters, GeneralizedCentrifugalForceModelAgentParameters
         ):
@@ -321,14 +317,14 @@ class Simulation:
             )
         elif isinstance(parameters, CollisionFreeSpeedModelAgentParameters):
             model = py_jps.CollisionFreeSpeedModelState(
-                orientation=orientation_or_zero(parameters),
+                orientation=parameters.orientation,
                 time_gap=parameters.time_gap,
                 desired_speed=parameters.desired_speed,
                 radius=parameters.radius,
             )
         elif isinstance(parameters, CollisionFreeSpeedModelV2AgentParameters):
             model = py_jps.CollisionFreeSpeedModelV2State(
-                orientation=orientation_or_zero(parameters),
+                orientation=parameters.orientation,
                 strength_neighbor_repulsion=parameters.strength_neighbor_repulsion,
                 range_neighbor_repulsion=parameters.range_neighbor_repulsion,
                 strength_geometry_repulsion=parameters.strength_geometry_repulsion,
@@ -339,7 +335,7 @@ class Simulation:
             )
         elif isinstance(parameters, CollisionFreeSpeedModelV3AgentParameters):
             model = py_jps.CollisionFreeSpeedModelV3State(
-                orientation=orientation_or_zero(parameters),
+                orientation=parameters.orientation,
                 strength_neighbor_repulsion=parameters.strength_neighbor_repulsion,
                 range_neighbor_repulsion=parameters.range_neighbor_repulsion,
                 strength_geometry_repulsion=parameters.strength_geometry_repulsion,
@@ -354,7 +350,7 @@ class Simulation:
             )
         elif isinstance(parameters, AnticipationVelocityModelAgentParameters):
             model = py_jps.AnticipationVelocityModelState(
-                orientation=orientation_or_zero(parameters),
+                orientation=parameters.orientation,
                 strength_neighbor_repulsion=parameters.strength_neighbor_repulsion,
                 range_neighbor_repulsion=parameters.range_neighbor_repulsion,
                 wall_buffer_distance=parameters.wall_buffer_distance,
@@ -377,7 +373,7 @@ class Simulation:
             )
         elif isinstance(parameters, WarpDriverModelAgentParameters):
             model = py_jps.WarpDriverModelState(
-                orientation=orientation_or_zero(parameters),
+                orientation=parameters.orientation,
                 desired_speed=parameters.desired_speed,
                 radius=parameters.radius,
             )

--- a/python_modules/jupedsim/jupedsim/simulation.py
+++ b/python_modules/jupedsim/jupedsim/simulation.py
@@ -299,10 +299,17 @@ class Simulation:
             Returns:
                 Id of the added agent.
         """
+
+        def orientation_or_zero(param):
+            if hasattr(param, "orientation"):
+                return param.orientation
+            return (0.0, 0.0)
+
         if isinstance(
             parameters, GeneralizedCentrifugalForceModelAgentParameters
         ):
             model = py_jps.GeneralizedCentrifugalForceModelState(
+                orientation=orientation_or_zero(parameters),
                 speed=parameters.speed,
                 desired_direction=parameters.desired_direction,
                 mass=parameters.mass,
@@ -315,12 +322,14 @@ class Simulation:
             )
         elif isinstance(parameters, CollisionFreeSpeedModelAgentParameters):
             model = py_jps.CollisionFreeSpeedModelState(
+                orientation=orientation_or_zero(parameters),
                 time_gap=parameters.time_gap,
                 desired_speed=parameters.desired_speed,
                 radius=parameters.radius,
             )
         elif isinstance(parameters, CollisionFreeSpeedModelV2AgentParameters):
             model = py_jps.CollisionFreeSpeedModelV2State(
+                orientation=orientation_or_zero(parameters),
                 strength_neighbor_repulsion=parameters.strength_neighbor_repulsion,
                 range_neighbor_repulsion=parameters.range_neighbor_repulsion,
                 strength_geometry_repulsion=parameters.strength_geometry_repulsion,
@@ -331,6 +340,7 @@ class Simulation:
             )
         elif isinstance(parameters, CollisionFreeSpeedModelV3AgentParameters):
             model = py_jps.CollisionFreeSpeedModelV3State(
+                orientation=orientation_or_zero(parameters),
                 strength_neighbor_repulsion=parameters.strength_neighbor_repulsion,
                 range_neighbor_repulsion=parameters.range_neighbor_repulsion,
                 strength_geometry_repulsion=parameters.strength_geometry_repulsion,
@@ -345,6 +355,7 @@ class Simulation:
             )
         elif isinstance(parameters, AnticipationVelocityModelAgentParameters):
             model = py_jps.AnticipationVelocityModelState(
+                orientation=orientation_or_zero(parameters),
                 strength_neighbor_repulsion=parameters.strength_neighbor_repulsion,
                 range_neighbor_repulsion=parameters.range_neighbor_repulsion,
                 wall_buffer_distance=parameters.wall_buffer_distance,
@@ -367,24 +378,15 @@ class Simulation:
             )
         elif isinstance(parameters, WarpDriverModelAgentParameters):
             model = py_jps.WarpDriverModelState(
+                orientation=orientation_or_zero(parameters),
                 desired_speed=parameters.desired_speed,
                 radius=parameters.radius,
             )
-
-        # TODO(kkratz): Some models do not have an orientation as part of their
-        # state, but we initially designed it to be. This needs to be first
-        # fixed on the C++ Level and then later here. Fix is: Move orientation
-        # into model specific data.
-        def orientation_or_zero(param):
-            if hasattr(param, "orientation"):
-                return param.orientation
-            return (0.0, 0.0)
 
         agent = py_jps.Agent(
             journey_id=parameters.journey_id,
             stage_id=parameters.stage_id,
             position=parameters.position,
-            orientation=orientation_or_zero(parameters),
             model=model,
         )
         return self._obj.add_agent(agent)

--- a/python_modules/jupedsim/jupedsim/simulation.py
+++ b/python_modules/jupedsim/jupedsim/simulation.py
@@ -300,16 +300,15 @@ class Simulation:
                 Id of the added agent.
         """
 
+        # Helper function to allow not passing orientation to models not requiring it.
         def orientation_or_zero(param):
-            if hasattr(param, "orientation"):
-                return param.orientation
-            return (0.0, 0.0)
+            return getattr(param, "orientation", (0.0, 0.0))
 
         if isinstance(
             parameters, GeneralizedCentrifugalForceModelAgentParameters
         ):
             model = py_jps.GeneralizedCentrifugalForceModelState(
-                orientation=orientation_or_zero(parameters),
+                orientation=parameters.orientation,
                 speed=parameters.speed,
                 desired_direction=parameters.desired_direction,
                 mass=parameters.mass,

--- a/python_modules/jupedsim/jupedsim/sqlite_serialization.py
+++ b/python_modules/jupedsim/jupedsim/sqlite_serialization.py
@@ -10,7 +10,7 @@ from shapely import from_wkt
 from jupedsim.serialization import TrajectoryWriter
 from jupedsim.simulation import Simulation
 
-DATABASE_VERSION: Final = 2
+DATABASE_VERSION: Final = 3
 
 
 def get_database_version(connection: sqlite3.Connection) -> int:
@@ -85,9 +85,7 @@ class SqliteTrajectoryWriter(TrajectoryWriter):
                 "   frame INTEGER NOT NULL,"
                 "   id INTEGER NOT NULL,"
                 "   pos_x REAL NOT NULL,"
-                "   pos_y REAL NOT NULL,"
-                "   ori_x REAL NOT NULL,"
-                "   ori_y REAL NOT NULL)"
+                "   pos_y REAL NOT NULL)"
             )
             cur.execute("DROP TABLE IF EXISTS metadata")
             cur.execute(
@@ -145,13 +143,11 @@ class SqliteTrajectoryWriter(TrajectoryWriter):
                     agent.id,
                     agent.position[0],
                     agent.position[1],
-                    agent.orientation[0],
-                    agent.orientation[1],
                 )
                 for agent in simulation.agents()
             ]
             cur.executemany(
-                "INSERT INTO trajectory_data VALUES(?, ?, ?, ?, ?, ?)",
+                "INSERT INTO trajectory_data VALUES(?, ?, ?, ?)",
                 frame_data,
             )
 
@@ -237,9 +233,10 @@ def update_database_to_latest_version(connection: sqlite3.Connection):
         convert_database_v1_to_v2(connection)
         version = 2
 
-    # if version == 2:
-    #     convert_database_v2_to_v3
-    #     version = 3
+    if version == 2:
+        convert_database_v2_to_v3(connection)
+        version = 3
+
     # ... for future versions
 
 
@@ -281,5 +278,28 @@ def convert_database_v1_to_v2(connection: sqlite3.Connection):
         )
         cur.execute("COMMIT")
         cur.execute("VACUUM")
+    except sqlite3.Error as e:
+        raise TrajectoryWriter.Exception(f"Error writing to database: {e}")
+
+
+def convert_database_v2_to_v3(connection: sqlite3.Connection):
+    cur = connection.cursor()
+
+    try:
+        cur.execute("BEGIN")
+
+        version = get_database_version(connection)
+        if version != 2:
+            raise RuntimeError(
+                f"Internal Error: When converting from database version 2 to 3, encountered database version {version}."
+            )
+
+        # Orientation (ori_x, ori_y) does no longer exist. Only change
+        # the version in-place as v2 only has additional data we just ignore.
+        cur.execute(
+            "UPDATE metadata SET value = ? WHERE key = ?", (3, "version")
+        )
+
+        cur.execute("COMMIT")
     except sqlite3.Error as e:
         raise TrajectoryWriter.Exception(f"Error writing to database: {e}")

--- a/python_modules/jupedsim/tests/test_recordings.py
+++ b/python_modules/jupedsim/tests/test_recordings.py
@@ -49,5 +49,50 @@ def test_can_read_db():
         ):
             assert agent.id == test_data[1]
             assert agent.position == (test_data[2], test_data[3])
-            assert agent.orientation == (test_data[4], test_data[5])
+    assert rec.geometry() is not None
+
+
+def test_can_read_db_without_orientation():
+    # v3 drops orientations (ori_x / ori_y)
+    db_name = "file:memdb_no_orientation?mode=memory&cache=shared"
+    db = sqlite3.connect(db_name, uri=True)
+    with db:
+        db.execute(
+            "CREATE TABLE metadata(key TEXT NOT NULL, value TEXT NOT NULL)"
+        )
+        db.executemany(
+            "INSERT INTO metadata VALUES(?, ?)", (("version", 3), ("fps", 25))
+        )
+        db.execute(
+            "CREATE TABLE geometry(hash INTEGER NOT NULL, wkt TEXT NOT NULL)"
+        )
+        db.execute(
+            "INSERT INTO geometry VALUES(?, ?)",
+            (0, "GEOMETRYCOLLECTION(POLYGON((0 0, 0 1, 1 1, 1 0, 0 0)))"),
+        )
+        db.execute(
+            "CREATE TABLE frame_data("
+            "   frame INTEGER NOT NULL,"
+            "   geometry_hash INTEGER NOT NULL)"
+        )
+        db.execute("INSERT INTO frame_data VALUES(?, ?)", (0, 0))
+        db.execute(
+            "CREATE TABLE trajectory_data ("
+            "   frame INTEGER NOT NULL,"
+            "   id INTEGER NOT NULL,"
+            "   pos_x REAL NOT NULL,"
+            "   pos_y REAL NOT NULL)"
+        )
+        data = [
+            (0, 1, 1.1, 2.2),
+            (0, 2, 3.3, 4.4),
+            (0, 3, 5.5, 6.6),
+        ]
+        db.executemany("INSERT INTO trajectory_data VALUES(?,?,?,?)", data)
+    rec = Recording(db_name, uri=True)
+    frame = rec.frame(0)
+    assert frame.index == 0
+    for agent, test_data in zip(frame.agents, data):
+        assert agent.id == test_data[1]
+        assert agent.position == (test_data[2], test_data[3])
     assert rec.geometry() is not None

--- a/systemtest/test_hdf5_writer.py
+++ b/systemtest/test_hdf5_writer.py
@@ -85,7 +85,7 @@ def test_metadata_attributes(square_simulation):
         ):
             assert key in hf.attrs, f"missing root attribute '{key}'"
         assert hf.attrs["producer"] == "JuPedSim"
-        assert hf.attrs["schema_version"] == 1
+        assert hf.attrs["schema_version"] == 2
 
 
 def test_close_is_idempotent(tmp_path):


### PR DESCRIPTION
Move orientation from GenericAgent to ModelData and remove it from SoialForceModel as it is derived there from velocity. Still expose orientation in Agent as read-only property as so far all models do provide it - though not necessarily as class attributes.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1601/
<!-- PREVIEW-URL-END -->