### PR TITLE
Expose neighborhood and geometry queries to Python

### DIFF
--- a/python_bindings_jupedsim/CMakeLists.txt
+++ b/python_bindings_jupedsim/CMakeLists.txt
@@ -1,25 +1,28 @@
 add_library(py_jupedsim MODULE
+    agent.cpp
+    anticipation_velocity_model.cpp
     bindings_jupedsim.cpp
     build_info.cpp
-    conversion.cpp
-    conversion.hpp
-    generalized_centrifugal_force_model.cpp
     collision_free_speed_model.cpp
     collision_free_speed_model_v2.cpp
     collision_free_speed_model_v3.cpp
-    anticipation_velocity_model.cpp
-    social_force_model.cpp
-    warp_driver_model.cpp
+    conversion.cpp
+    conversion.hpp
+    generalized_centrifugal_force_model.cpp
+    geometry.cpp
+    journey.cpp
+    linesegment.cpp
     logging.cpp
     logging.hpp
-    trace.cpp
-    geometry.cpp
+    neighborhood_search.cpp
     routing.cpp
     simulation.cpp
-    agent.cpp
+    social_force_model.cpp
     stage.cpp
-    journey.cpp
+    trace.cpp
     transition.cpp
+    type_casters.hpp
+    warp_driver_model.cpp
 )
 
 target_link_libraries(py_jupedsim

--- a/python_bindings_jupedsim/bindings_jupedsim.cpp
+++ b/python_bindings_jupedsim/bindings_jupedsim.cpp
@@ -21,6 +21,8 @@ void init_transition(py::module_& m);
 void init_journey(py::module_& m);
 void init_stage(py::module_& m);
 void init_simulation(py::module_& m);
+void init_neighborhood_search(py::module_& m);
+void init_linesegment(py::module_& m);
 
 PYBIND11_MODULE(py_jupedsim, m)
 {
@@ -35,10 +37,12 @@ PYBIND11_MODULE(py_jupedsim, m)
     init_anticipation_velocity_model(m);
     init_social_force_model(m);
     init_warp_driver_model(m);
+    init_linesegment(m);
     init_geometry(m);
     init_routing(m);
     init_agent(m);
     init_transition(m);
     init_stage(m);
     init_simulation(m);
+    init_neighborhood_search(m);
 }

--- a/python_bindings_jupedsim/conversion.hpp
+++ b/python_bindings_jupedsim/conversion.hpp
@@ -3,7 +3,10 @@
 
 #include <Point.hpp>
 
+#include <iterator>
+#include <ranges>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 std::tuple<double, double> intoTuple(const Point& p);
@@ -19,10 +22,22 @@ std::vector<std::tuple<double, double>> intoTuples(const auto& in)
     return tuples;
 }
 
-
 Point intoPoint(const std::tuple<double, double>& p);
 
 std::vector<Point> intoPoints(const std::vector<std::tuple<double, double>>& in);
+
+template <typename Range>
+auto intoVec(Range&& range)
+{
+    using Value = std::remove_cvref_t<decltype(*std::begin(range))>;
+
+    std::vector<Value> result{};
+    result.reserve(std::ranges::size(range));
+    for(auto&& value : range) {
+        result.emplace_back(value);
+    }
+    return result;
+}
 
 template <typename T, typename U>
 std::vector<T> intoVecT(const std::vector<U>& vec)

--- a/python_bindings_jupedsim/geometry.cpp
+++ b/python_bindings_jupedsim/geometry.cpp
@@ -19,15 +19,23 @@ void init_geometry(py::module_& m)
             [](const CollisionGeometry& geo) {
                 return intoTuples(std::get<0>(geo.AccessibleArea()));
             })
-        .def("holes", [](const CollisionGeometry& geo) {
-            const auto holes = std::get<1>(geo.AccessibleArea());
-            std::vector<std::vector<std::tuple<double, double>>> res{};
-            res.reserve(holes.size());
-            for(const auto& hole : holes) {
-                res.emplace_back(intoTuples(hole));
-            }
-            return res;
-        });
+        .def(
+            "holes",
+            [](const CollisionGeometry& geo) {
+                const auto holes = std::get<1>(geo.AccessibleArea());
+                std::vector<std::vector<std::tuple<double, double>>> res{};
+                res.reserve(holes.size());
+                for(const auto& hole : holes) {
+                    res.emplace_back(intoTuples(hole));
+                }
+                return res;
+            })
+        .def("linesegments_close_to", &CollisionGeometry::LineSegmentsInApproxDistanceTo)
+        .def(
+            "linesegments_in_distance_to",
+            [](const CollisionGeometry& geo, double distance, std::tuple<double, double> pos) {
+                return intoVec(geo.LineSegmentsInDistanceTo(distance, intoPoint(pos)));
+            });
     py::class_<GeometryBuilder>(m, "GeometryBuilder")
         .def(py::init<>())
         .def(

--- a/python_bindings_jupedsim/linesegment.cpp
+++ b/python_bindings_jupedsim/linesegment.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include "LineSegment.hpp"
+
+// Keep include for pybind11 typecasters to be picked up
+#include "type_casters.hpp" // IWYU pragma: keep
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+void init_linesegment(py::module_& m)
+{
+    py::class_<LineSegment>(m, "LineSegment")
+        .def_readonly("p1", &LineSegment::p1)
+        .def_readonly("p2", &LineSegment::p2)
+        .def("shortest_point", &LineSegment::ShortestPoint, py::arg("p"))
+        .def("dist_to", &LineSegment::DistTo, py::arg("p"));
+}

--- a/python_bindings_jupedsim/neighborhood_search.cpp
+++ b/python_bindings_jupedsim/neighborhood_search.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include "GenericAgent.hpp"
+#include "NeighborhoodSearch.hpp"
+#include "conversion.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+void init_neighborhood_search(py::module_& m)
+{
+    py::class_<NeighborhoodSearch<GenericAgent>>(m, "NeighborhoodSearch")
+        .def(
+            "get_neighboring_agents",
+            [](NeighborhoodSearch<GenericAgent>& self,
+               const std::tuple<double, double>& pos,
+               double radius) { return self.GetNeighboringAgents(intoPoint(pos), radius); },
+            py::arg("pos"),
+            py::arg("radius"),
+            "Get agents within a certain radius of a position (by value)");
+}

--- a/python_bindings_jupedsim/type_casters.hpp
+++ b/python_bindings_jupedsim/type_casters.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "Point.hpp"
+
+#include <pybind11/pybind11.h>
+
+// Type caster: According to https://pybind11.readthedocs.io/en/stable/advanced/cast/custom.html
+// which coincidentally also shows a conversion for Point2D. :)
+namespace pybind11::detail
+{
+template <>
+struct type_caster<Point> {
+    PYBIND11_TYPE_CASTER(Point, const_name("tuple[float, float]"));
+
+    bool load(handle src, bool)
+    {
+        if(!isinstance<sequence>(src)) {
+            return false;
+        }
+        auto seq = reinterpret_borrow<sequence>(src);
+        if(seq.size() != 2) {
+            return false;
+        }
+        value.x = seq[0].cast<double>();
+        value.y = seq[1].cast<double>();
+        return true;
+    }
+
+    static handle cast(const Point& src, return_value_policy, handle)
+    {
+        return make_tuple(src.x, src.y).release();
+    }
+};
+} // namespace pybind11::detail

--- a/python_modules/jupedsim/jupedsim/__init__.py
+++ b/python_modules/jupedsim/jupedsim/__init__.py
@@ -32,6 +32,7 @@ from jupedsim.library import (
     set_info_callback,
     set_warning_callback,
 )
+from jupedsim.linesegment import LineSegment
 from jupedsim.models.anticipation_velocity_model import (
     AnticipationVelocityModel,
     AnticipationVelocityModelAgentParameters,
@@ -67,6 +68,7 @@ from jupedsim.models.warp_driver import (
     WarpDriverModelAgentParameters,
     WarpDriverModelState,
 )
+from jupedsim.neighborhood import NeighborhoodSearch
 from jupedsim.recording import Recording, RecordingAgent, RecordingFrame
 from jupedsim.routing import RoutingEngine
 from jupedsim.serialization import TrajectoryWriter
@@ -112,9 +114,11 @@ __all__ = [
     "GeneralizedCentrifugalForceModel",
     "GeneralizedCentrifugalForceModelState",
     "Geometry",
+    "LineSegment",
     "IncorrectParameterError",
     "JourneyDescription",
     "NegativeValueError",
+    "NeighborhoodSearch",
     "NotifiableQueueStage",
     "OverlappingCirclesError",
     "Recording",

--- a/python_modules/jupedsim/jupedsim/geometry.py
+++ b/python_modules/jupedsim/jupedsim/geometry.py
@@ -3,6 +3,7 @@
 import shapely
 
 import jupedsim.native as py_jps
+from jupedsim.linesegment import LineSegment
 
 
 class Geometry:
@@ -45,3 +46,54 @@ class Geometry:
             poly,
             rounding_precision=-1,
         )
+
+    def linesegments_close_to(
+        self, point: tuple[float, float]
+    ) -> list[LineSegment]:
+        """Find line segments of the geometry that are within a certain distance to a point.
+
+        Args:
+            point (tuple[float, float]): The point to check against.
+            distance (float): The maximum distance for line segments to be included.
+
+        Returns:
+            List of LineSegment objects that are close to the given point.
+        """
+        ls_list = []
+        for ls in self._obj.linesegments_close_to(point):
+            ls_list.append(LineSegment(ls))
+        return ls_list
+
+    def get_walls_close_to(
+        self, point: tuple[float, float]
+    ) -> list[LineSegment]:
+        """Find line segments of the geometry that are within a certain distance to a point.
+
+        Args:
+            point (tuple[float, float]): The point to check against.
+            distance (float): The maximum distance for line segments to be included.
+
+        Returns:
+            List of LineSegment objects that are close to the given point.
+        """
+        ls_list = []
+        for ls in self._obj.linesegments_close_to(point):
+            ls_list.append(LineSegment(ls))
+        return ls_list
+
+    def get_walls_in_distance_to(
+        self, point: tuple[float, float], distance: float
+    ) -> list[LineSegment]:
+        """Find line segments of the geometry that are within a certain distance to a point.
+
+        Args:
+            point (tuple[float, float]): The point to check against.
+            distance (float): The maximum distance for line segments to be included.
+
+        Returns:
+            List of LineSegment objects that are close to the given point.
+        """
+        ls_list = []
+        for ls in self._obj.linesegments_in_distance_to(distance, point):
+            ls_list.append(LineSegment(ls))
+        return ls_list

--- a/python_modules/jupedsim/jupedsim/linesegment.py
+++ b/python_modules/jupedsim/jupedsim/linesegment.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+import jupedsim.native as py_jps
+
+
+class LineSegment:
+    """Represents a line segment in 2D space, defined by two endpoints p1 and p2."""
+
+    def __init__(self, obj: py_jps.LineSegment):
+        """Initialize the LineSegment with a native LineSegment object.
+
+        Args:
+            obj (py_jps.LineSegment): The native LineSegment object to wrap.
+        """
+        self._obj = obj
+
+    @property
+    def p1(self) -> tuple[float, float]:
+        """Get the first endpoint of the line segment."""
+        return self._obj.p1
+
+    @property
+    def p2(self) -> tuple[float, float]:
+        """Get the second endpoint of the line segment."""
+        return self._obj.p2
+
+    def distance_to_point(self, point: tuple[float, float]) -> float:
+        """Calculate the distance from a given point to this line segment.
+
+        Args:
+            point (tuple[float, float]): The point to calculate the distance to.
+
+        Returns:
+            float: The distance from the point to the line segment.
+        """
+        return self._obj.dist_to(point)
+
+    def closest_point(self, point: tuple[float, float]) -> tuple[float, float]:
+        """Calculate the closest point on the line segment to a given point.
+
+        Args:
+            point (tuple[float, float]): The point to find the closest point to.
+
+        Returns:
+            tuple[float, float]: The closest point on the line segment to the given point.
+        """
+        return self._obj.shortest_point(point)

--- a/python_modules/jupedsim/jupedsim/neighborhood.py
+++ b/python_modules/jupedsim/jupedsim/neighborhood.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+"""
+Pure Python wrapper for neighborhood search C++ bindings.
+
+This module provides a Pythonic interface to the underlying C++ NeighborhoodSearch
+implementation, making it easier to work with spatial queries in operational models.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Tuple
+
+import jupedsim.native as py_jps
+
+if TYPE_CHECKING:
+    from jupedsim.agent import Agent
+
+
+class NeighborhoodSearch:
+    """
+    Pure Python wrapper for the C++ NeighborhoodSearch class.
+
+    Provides efficient spatial queries for finding neighboring agents within
+    a given radius. Uses a grid-based data structure for O(1) cell lookups
+    with configurable cell size.
+
+
+    Example:
+        >>> neighbors = neighborhood.get_neighboring_agents(
+        ...     position=(5.0, 5.0),
+        ...     radius=2.0
+        ... )
+    """
+
+    def __init__(self, obj: py_jps.NeighborhoodSearch):
+        """
+        Wrap an existing C++
+        """
+        self._obj = obj
+
+    def get_neighboring_agents(
+        self, position: Tuple[float, float], radius: float
+    ) -> "List[Agent]":
+        """
+        Get all agents within a certain radius of a position.
+
+        Uses the underlying spatial grid for efficient O(1) average-case
+        lookup time (worst case depends on number of agents per cell).
+
+        Args:
+            position: Query position as (x, y) tuple [m]
+            radius: Search radius [m]
+
+        Returns:
+            List of GenericAgent objects within the radius.
+            Empty list if no agents found.
+
+        Raises:
+            ValueError: If radius < 0
+
+        Example:
+            >>> neighbors = neighborhood.get_neighboring_agents(
+            ...     position=(5.0, 5.0),
+            ...     radius=2.5
+            ... )
+            >>> print(f"Found {len(neighbors)} neighbors")
+        """
+        from jupedsim.agent import Agent
+
+        if radius < 0:
+            raise ValueError(f"radius must be non-negative, got {radius}")
+
+        neighbors = self._obj.get_neighboring_agents(position, radius)
+        return [Agent(x) for x in neighbors]


### PR DESCRIPTION
Add Python bindings and wrappers for querying neighboring agents from NeighborhoodSearch and nearby geometry line segments from Geometry. These APIs are needed by Python operational models to inspect their local environment during model evaluation.

Also bind LineSegment, add a Point type caster for direct tuple conversion, and add a generic binding-side range-to-vector helper for exposing iterator ranges.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1602/
<!-- PREVIEW-URL-END -->