### PR TITLE
Add documentation about Profiling and Timing in JuPedSim

### DIFF
--- a/docs/source/concepts/index.rst
+++ b/docs/source/concepts/index.rst
@@ -17,9 +17,6 @@ If you want to know in more detail how the simulation works, have a look:
     * - :doc:`Custom Serialization <custom_serialization>`
       - How to write a custom trajectory serializer
 
-    * - :doc:`Profiling and Timing <profiling_and_timing>`
-      - How to measure and visualize simulation performance
-
 .. toctree::
     :maxdepth: 1
     :hidden:
@@ -27,4 +24,3 @@ If you want to know in more detail how the simulation works, have a look:
     Geometry <geometry>
     Routing <routing>
     Custom Serialization <custom_serialization>
-    Profiling and Timing <profiling_and_timing>

--- a/docs/source/concepts/index.rst
+++ b/docs/source/concepts/index.rst
@@ -17,6 +17,9 @@ If you want to know in more detail how the simulation works, have a look:
     * - :doc:`Custom Serialization <custom_serialization>`
       - How to write a custom trajectory serializer
 
+    * - :doc:`Profiling and Timing <profiling_and_timing>`
+      - How to measure and visualize simulation performance
+
 .. toctree::
     :maxdepth: 1
     :hidden:
@@ -24,3 +27,4 @@ If you want to know in more detail how the simulation works, have a look:
     Geometry <geometry>
     Routing <routing>
     Custom Serialization <custom_serialization>
+    Profiling and Timing <profiling_and_timing>

--- a/docs/source/debugging/index.rst
+++ b/docs/source/debugging/index.rst
@@ -1,0 +1,18 @@
+===================
+Tools for Debugging
+===================
+
+The tools implemented as part of JuPedSim, that can help with debugging or profiling your simulation are presented in this section.
+For details have a look at:
+
+.. list-table::
+    :widths: 10 90
+
+    * - :doc:`Profiling and Timing <profiling_and_timing>`
+      - How to measure and visualize simulation performance
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+    Profiling and Timing <profiling_and_timing>

--- a/docs/source/debugging/index.rst
+++ b/docs/source/debugging/index.rst
@@ -6,7 +6,7 @@ The tools implemented as part of JuPedSim, that can help with debugging or profi
 For details have a look at:
 
 .. list-table::
-    :widths: 10 90
+    :widths: 30 70
 
     * - :doc:`Profiling and Timing <profiling_and_timing>`
       - How to measure and visualize simulation performance

--- a/docs/source/debugging/profiling_and_timing.rst
+++ b/docs/source/debugging/profiling_and_timing.rst
@@ -1,0 +1,393 @@
+.. _profiling_and_timing:
+
+====================
+Profiling and Timing
+====================
+
+*JuPedSim* provides two complementary instrumentation systems that work on both
+the C++ core and from Python:
+
+* **Timer** — lightweight wall-clock measurement that accumulates elapsed time
+  per named region.  Useful for comparing the relative cost of simulation
+  subsystems and for writing results to CSV.
+* **Profiler** — Perfetto-based tracing that records a full timeline of events
+  to a ``.pftrace`` file.  Useful for visual inspection in `Perfetto UI
+  <https://ui.perfetto.dev>`_.
+
+Both systems are available through the ``jupedsim`` public API, so no C++
+knowledge is required to use them.
+
+-------
+Timings
+-------
+
+How it works
+============
+
+Every :class:`~jupedsim.simulation.Simulation` instance owns a
+:class:`~jupedsim.internal.tracing.Timer`.  The timer is backed by the C++
+``Timer`` class which uses ``std::chrono::high_resolution_clock``.  Elapsed
+time is accumulated in **microseconds** across all ``push`` / ``pop`` calls for
+the same name, so multiple intervals are summed together.
+
+Timer log levels
+================
+
+Each timer probe carries a *probe log level*.  The simulation's *timer log
+level* acts as a filter: only probes with a level **≤** the simulation's
+log level are recorded.
+
++-------+------------+
+| Value | Meaning    |
++=======+============+
+|   1   | General    |
++-------+------------+
+|   2   | Detailed   |
++-------+------------+
+|   3   | Debug      |
++-------+------------+
+
+Pass ``timer_log_level`` when creating the simulation:
+
+.. code:: python
+
+    import jupedsim as jps
+
+    sim = jps.Simulation(
+        model=jps.CollisionFreeSpeedModel(),
+        geometry=geometry,
+        timer_log_level=3,   # record everything including debug probes
+    )
+
+The default is ``1`` (General).
+
+Built-in timer keys
+===================
+
+The C++ core automatically times these regions during every call to
+:meth:`~jupedsim.simulation.Simulation.iterate`:
+
+* ``"Total Simulation Time"`` — running total since the simulation was created
+* ``"Total Iteration"`` — cumulative time spent inside ``iterate()``
+* ``"Agent Removal System"``
+* ``"Neighborhood Search"``
+* ``"Stage System"``
+* ``"Strategical Decision System"``
+* ``"Tactical Decision System"``
+* ``"Operational Decision System"``
+* ``"Add Agent"``
+* ``"Add Journey"``
+
+Python timer API
+================
+
+The timer is accessed via :attr:`simulation.timer`.
+
+Measuring a code block
+----------------------
+
+Use :meth:`~jupedsim.internal.tracing.Timer.push_timer` and
+:meth:`~jupedsim.internal.tracing.Timer.pop_timer` to bracket any region:
+
+.. code:: python
+
+    sim.timer.push_timer("my_preprocessing")
+    # ... work ...
+    sim.timer.pop_timer("my_preprocessing")
+
+    elapsed = sim.timer.elapsed_time_us("my_preprocessing")
+    print(f"preprocessing took {elapsed / 1000:.2f} ms")
+
+The name is free-form; the same name can be pushed and popped multiple times
+and the durations accumulate.
+
+Decorator usage
+---------------
+
+Decorate a function so that every call is automatically timed:
+
+.. code:: python
+
+    @sim.timer.timer_event
+    def spawn_agents():
+        for pos in positions:
+            sim.add_agent(...)
+
+    spawn_agents()   # timer key "spawn_agents()" is recorded
+
+Use ``name=`` to override the key:
+
+.. code:: python
+
+    @sim.timer.timer_event(name="agent-init")
+    def spawn_agents():
+        ...
+
+Context-manager usage
+---------------------
+
+Wrap any inline block without defining a function:
+
+.. code:: python
+
+    with sim.timer.timer_event("route-computation"):
+        for agent_id in agent_ids:
+            routing.compute_waypoints(...)
+
+Per-iteration timing
+--------------------
+
+:attr:`sim.timer.iteration_duration_us` returns the
+time spent in the **last** call to ``iterate()``, making it easy to display
+live throughput:
+
+.. code:: python
+
+    while sim.agent_count() > 0:
+        sim.iterate()
+        it_ms = sim.timer.iteration_duration_us / 1000
+        print(f"iteration {sim.iteration_count():5d}  {it_ms:.2f} ms/it", end="\r")
+
+:attr:`~jupedsim.internal.tracing.Timer.operational_level_duration_us` is the
+analogous per-iteration time for the Operational Decision System subsystem
+only.
+
+Reading all accumulated durations
+----------------------------------
+
+Call :meth:`~jupedsim.internal.tracing.Timer.elapsed_time_us` with a key to
+get a single value, or retrieve all keys at once from the underlying C++
+object:
+
+.. code:: python
+
+    keys = [
+        "Total Simulation Time",
+        "Neighborhood Search",
+        "Operational Decision System",
+    ]
+    for key in keys:
+        us = sim.timer.elapsed_time_us(key)
+        print(f"{key:<35} {us / 1_000_000:.3f} s")
+
+Formatted timing report
+-----------------------
+
+Converting the timer to a string prints a human-readable table.
+Entries below 0.01 % of total time are suppressed:
+
+.. code:: python
+
+    print(sim.timer)
+
+Example output::
+
+    JuPedSim Timings:
+    -----------------------------------------------------
+    Total Iteration               |    12.34 s (98.72%)
+    Neighborhood Search           |     3.21 s (25.69%)
+    Operational Decision System   |     8.10 s (64.82%)
+    Strategical Decision System   |     0.02 s ( 0.16%)
+    -----------------------------------------------------
+    Total Simulation Time         |    12.50 s
+
+Saving timing results to CSV
+-----------------------------
+
+.. code:: python
+
+    import pandas as pd
+
+    keys = [
+        "Total Simulation Time",
+        "Neighborhood Search",
+        "Operational Decision System",
+    ]
+
+    row = {key: sim.timer.elapsed_time_us(key) for key in keys}
+    df = pd.DataFrame([row])
+    df.to_csv("timings.csv", index=False)
+
+--------
+Tracing
+--------
+
+How it works
+============
+
+The Profiler records a timeline of named events using
+`Perfetto <https://perfetto.dev>`_.  When enabled, events from both the C++
+core and from Python code are written continuously to a temporary
+``.pftrace`` file on disk.  Calling :func:`~jupedsim.dump_traces` stops the
+session and moves the temporary file to the path you specify.
+
+Traces can be inspected visually at `ui.perfetto.dev <https://ui.perfetto.dev>`_
+by loading the saved file.
+
+.. note::
+   The Profiler is a process-wide singleton.  Enabling it adds overhead to
+   every instrumented C++ function.  Leave it disabled for production
+   benchmarks.
+
+Python profiler API
+===================
+
+All profiler functions are available directly from ``jupedsim``:
+
+.. code:: python
+
+    import jupedsim as jps
+
+Enabling and disabling
+----------------------
+
+.. code:: python
+
+    jps.enable_tracing()
+
+    # ... run your simulation ...
+
+    jps.disable_tracing()   # discards the trace without saving
+
+Saving the trace
+----------------
+
+:func:`~jupedsim.dump_traces` stops the session, saves the trace, and resets
+the profiler so a new session can be started:
+
+.. code:: python
+
+    jps.enable_tracing()
+
+    while sim.agent_count() > 0:
+        sim.iterate()
+
+    jps.dump_traces("simulation.pftrace")
+
+Open ``simulation.pftrace`` at `ui.perfetto.dev <https://ui.perfetto.dev>`_
+to view the full timeline.
+
+Checking whether tracing is active
+------------------------------------
+
+.. code:: python
+
+    if jps.is_tracing_enabled():
+        print("tracing is on")
+
+Manual event spans
+------------------
+
+Bracket any code region with explicit begin/end calls:
+
+.. code:: python
+
+    jps.start_trace_event("agent-spawning")
+    for pos in positions:
+        sim.add_agent(...)
+    jps.end_trace_event()
+
+Events nest correctly — each ``end_trace_event()`` closes the most recently
+opened event on the calling thread.
+
+Decorator usage
+---------------
+
+Decorate a function to wrap every call in a trace event:
+
+.. code:: python
+
+    @jps.trace_event
+    def spawn_agents():
+        for pos in positions:
+            sim.add_agent(...)
+
+    spawn_agents()   # recorded as "spawn_agents()" in the timeline
+
+Override the displayed name:
+
+.. code:: python
+
+    @jps.trace_event(name="agent-init")
+    def spawn_agents():
+        ...
+
+Context-manager usage
+---------------------
+
+.. code:: python
+
+    with jps.trace_event("route-computation"):
+        for agent_id in agent_ids:
+            routing.compute_waypoints(...)
+
+Saving mid-run on interrupt
+-----------------------------
+
+Use a ``try / except`` around the simulation loop so traces are always
+preserved even when the user presses :kbd:`Ctrl-C`:
+
+.. code:: python
+
+    import sys
+    import jupedsim as jps
+
+    jps.enable_tracing()
+    try:
+        while sim.agent_count() > 0:
+            sim.iterate()
+    except KeyboardInterrupt:
+        print("Interrupted — saving partial trace")
+        jps.dump_traces("partial_trace.pftrace")
+        sys.exit(1)
+
+    jps.dump_traces("full_trace.pftrace")
+
+---------------------------
+Combining Timing and Tracing
+---------------------------
+
+Both systems can be active simultaneously.  The timer gives you numbers;
+the profiler gives you a visual timeline with the same event boundaries.
+
+.. code:: python
+
+    import jupedsim as jps
+    import pandas as pd
+
+    sim = jps.Simulation(
+        model=jps.CollisionFreeSpeedModel(),
+        geometry=geometry,
+        timer_log_level=2,
+    )
+
+    jps.enable_tracing()
+
+    @sim.timer.timer_event
+    @jps.trace_event
+    def spawn_agents():
+        for pos in initial_positions:
+            sim.add_agent(...)
+
+    spawn_agents()
+
+    while sim.agent_count() > 0:
+        sim.iterate()
+
+    # save visual trace
+    jps.dump_traces("simulation.pftrace")
+
+    # print timing table
+    print(sim.timer)
+
+    # write per-subsystem timings to CSV
+    keys = [
+        "Total Simulation Time",
+        "Neighborhood Search",
+        "Operational Decision System",
+        "Strategical Decision System",
+        "Tactical Decision System",
+    ]
+    pd.DataFrame([{k: sim.timer.elapsed_time_us(k) for k in keys}]).to_csv(
+        "timings.csv", index=False
+    )

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ JuPedSim
    Concepts <concepts/index>
    Pedestrian Models <pedestrian_models/index>
    Notebooks <notebooks/index>
+   Debugging <debugging/index>
    History <history>
    Disclaimer <disclaimer>
    API reference <api/jupedsim/index>

--- a/libsimulator/src/Tracing.cpp
+++ b/libsimulator/src/Tracing.cpp
@@ -36,9 +36,6 @@ perfetto::TraceConfig buildDefaultTraceConfig(const std::string& output_path)
     // How often accumulated trace data is written from the in-memory ring buffer
     // to the file. Lower values reduce memory pressure; higher values reduce I/O.
     cfg.set_file_write_period_ms(100);
-    // How often data sources are asked to flush their pending events into the
-    // ring buffer so they are visible to the file writer above.
-    // cfg.set_flush_period_ms(100);
     // Maximum time to wait for a flush to complete before giving up.
     cfg.set_flush_timeout_ms(5000);
 

--- a/libsimulator/src/Tracing.cpp
+++ b/libsimulator/src/Tracing.cpp
@@ -2,6 +2,7 @@
 
 #include "Logger.hpp"
 
+#include <fmt/core.h>
 #include <perfetto.h>
 
 #include <chrono>
@@ -16,9 +17,8 @@ namespace
 std::string makeTempTracePath()
 {
     auto ts = std::chrono::steady_clock::now().time_since_epoch().count();
-    std::ostringstream name;
-    name << "jupedsim_trace_" << ts << ".pftrace";
-    return (std::filesystem::temp_directory_path() / name.str()).string();
+    std::string name = fmt::format("jupedsim_trace{}.pftrace", ts);
+    return (std::filesystem::temp_directory_path() / name).string();
 }
 
 perfetto::TraceConfig buildDefaultTraceConfig(const std::string& output_path)

--- a/libsimulator/src/Tracing.cpp
+++ b/libsimulator/src/Tracing.cpp
@@ -4,16 +4,24 @@
 
 #include <perfetto.h>
 
-#include <fstream>
-#include <iomanip>
-#include <iostream>
+#include <chrono>
+#include <filesystem>
+#include <sstream>
 #include <string>
 
 PERFETTO_TRACK_EVENT_STATIC_STORAGE();
 
 namespace
 {
-perfetto::TraceConfig buildDefaultTraceConfig()
+std::string makeTempTracePath()
+{
+    auto ts = std::chrono::steady_clock::now().time_since_epoch().count();
+    std::ostringstream name;
+    name << "jupedsim_trace_" << ts << ".pftrace";
+    return (std::filesystem::temp_directory_path() / name.str()).string();
+}
+
+perfetto::TraceConfig buildDefaultTraceConfig(const std::string& output_path)
 {
     perfetto::TraceConfig cfg;
 
@@ -22,6 +30,17 @@ perfetto::TraceConfig buildDefaultTraceConfig()
 
     auto* ds_cfg = cfg.add_data_sources()->mutable_config();
     ds_cfg->set_name("track_event");
+
+    cfg.set_write_into_file(true);
+    cfg.set_output_path(output_path);
+    // How often accumulated trace data is written from the in-memory ring buffer
+    // to the file. Lower values reduce memory pressure; higher values reduce I/O.
+    cfg.set_file_write_period_ms(100);
+    // How often data sources are asked to flush their pending events into the
+    // ring buffer so they are visible to the file writer above.
+    // cfg.set_flush_period_ms(100);
+    // Maximum time to wait for a flush to complete before giving up.
+    cfg.set_flush_timeout_ms(5000);
 
     return cfg;
 }
@@ -41,8 +60,10 @@ void Profiler::createSession()
 
     perfetto::TrackEvent::Register();
 
+    temp_trace_path = makeTempTracePath();
+
     tracing_session = perfetto::Tracing::NewTrace();
-    tracing_session->Setup(buildDefaultTraceConfig());
+    tracing_session->Setup(buildDefaultTraceConfig(temp_trace_path));
     tracing_session->StartBlocking();
 }
 
@@ -54,20 +75,29 @@ void Profiler::writeAndResetSession(const std::string& filename)
 
     perfetto::TrackEvent::Flush();
     tracing_session->StopBlocking();
-    const auto trace_data = tracing_session->ReadTraceBlocking();
-    if(filename.empty()) {
-        tracing_session.reset();
-        return;
-    }
-    std::ofstream output(filename, std::ios::binary | std::ios::trunc);
-    if(output.is_open()) {
-        output.write(trace_data.data(), static_cast<std::streamsize>(trace_data.size()));
-        output.flush();
-    } else {
-        LOG_ERROR("Failed to open Perfetto output file: {}", filename);
-    }
-
     tracing_session.reset();
+
+    if(!temp_trace_path.empty()) {
+        std::error_code ec;
+        if(filename.empty()) {
+            std::filesystem::remove(temp_trace_path, ec);
+        } else {
+            std::filesystem::rename(temp_trace_path, filename, ec);
+            if(ec) {
+                // rename fails across devices — copy then delete
+                std::filesystem::copy_file(
+                    temp_trace_path,
+                    filename,
+                    std::filesystem::copy_options::overwrite_existing,
+                    ec);
+                std::filesystem::remove(temp_trace_path);
+                if(ec) {
+                    LOG_ERROR("Failed to save Perfetto trace to: {}", filename);
+                }
+            }
+        }
+        temp_trace_path.clear();
+    }
 }
 
 void Profiler::enable()

--- a/libsimulator/src/Tracing.hpp
+++ b/libsimulator/src/Tracing.hpp
@@ -51,4 +51,5 @@ private:
     void writeAndResetSession(const std::string& filename);
     bool enabled{false};
     std::unique_ptr<perfetto::TracingSession> tracing_session{};
+    std::string temp_trace_path{};
 };


### PR DESCRIPTION
I add documentation on the profiling and timing functionality that we added to JuPedSim with a prior PR.
In addition I also change the dumping of traces to use Perfetto's build-in tool rather than a final dump.
The user can still give the name of the trace file by using `dump_traces("my file.pftrace")` which triggers a move of the temporary trace file written by perfetto.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1605/
<!-- PREVIEW-URL-END -->