### PR TITLE
Move kernel for 2D to EPICK

### DIFF
--- a/libsimulator/src/CfgCgal.hpp
+++ b/libsimulator/src/CfgCgal.hpp
@@ -10,7 +10,6 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_2.h>
 #include <CGAL/Polygon_with_holes_2.h>
-#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Triangulation_data_structure_2.h>
 #include <CGAL/Triangulation_vertex_base_2.h>
@@ -21,9 +20,9 @@
 #include <sstream>
 #include <string>
 
-// using K = CGAL::Exact_predicates_exact_constructions_kernel;
-using K = CGAL::Simple_cartesian<double>;
-using Point3 = K::Point_3;
+using K = CGAL::Exact_predicates_inexact_constructions_kernel;
+using Point2D = K::Point_2;
+using Point3D = K::Point_3;
 using Vector3 = K::Vector_3;
 
 using Poly = CGAL::Polygon_2<K>;
@@ -31,7 +30,7 @@ using PolyWithHoles = CGAL::Polygon_with_holes_2<K>;
 using PolyWithHolesList = std::list<PolyWithHoles>;
 using PolyList = std::list<Poly>;
 using Vb = CGAL::Triangulation_vertex_base_2<K>;
-using CGALMesh = CGAL::Surface_mesh<Point3>;
+using SurfaceMesh = CGAL::Surface_mesh<Point3D>;
 
 /// Convenience alias for vertex descriptor types
 template <class G>
@@ -49,14 +48,8 @@ using HalfedgeDescriptor = typename boost::graph_traits<G>::halfedge_descriptor;
 template <class G>
 using EdgeDescriptor = typename boost::graph_traits<G>::edge_descriptor;
 
-// 3D - Surface_mesh_shortest_path is designed for EPICK
-using SurfaceKernel = CGAL::Exact_predicates_inexact_constructions_kernel;
-using SurfaceMesh = CGAL::Surface_mesh<SurfaceKernel::Point_3>;
-using Point3D = SurfaceKernel::Point_3;
-using Point2D = SurfaceKernel::Point_2;
-using Segment3D = SurfaceKernel::Segment_3;
 using AABBPrimitive = CGAL::AABB_face_graph_triangle_primitive<SurfaceMesh>;
-using AABBTraits = CGAL::AABB_traits_3<SurfaceKernel, AABBPrimitive>;
+using AABBTraits = CGAL::AABB_traits_3<K, AABBPrimitive>;
 using AABBTree = CGAL::AABB_tree<AABBTraits>;
 
 template <class Gt, class Fb = CGAL::Constrained_triangulation_face_base_2<Gt>>

--- a/libsimulator/src/CfgCgal.hpp
+++ b/libsimulator/src/CfgCgal.hpp
@@ -23,7 +23,12 @@
 using K = CGAL::Exact_predicates_inexact_constructions_kernel;
 using Point2D = K::Point_2;
 using Point3D = K::Point_3;
-using Vector3 = K::Vector_3;
+using Triangle2D = K::Triangle_2;
+using Triangle3D = K::Triangle_3;
+using Vector3D = K::Vector_3;
+using Direction3D = K::Direction_3;
+using Line3D = K::Line_3;
+using Ray3D = K::Ray_3;
 
 using Poly = CGAL::Polygon_2<K>;
 using PolyWithHoles = CGAL::Polygon_with_holes_2<K>;

--- a/libsimulator/src/Geometry/Geometry3D.cpp
+++ b/libsimulator/src/Geometry/Geometry3D.cpp
@@ -51,7 +51,7 @@ bool face_covers(const SurfaceMesh& mesh, SurfaceMesh::Face_index f, const Point
         const auto& s = mesh.point(v);
         p[i++] = Point2D{s.x(), s.y()};
     }
-    return SurfaceKernel::Triangle_2(p[0], p[1], p[2]).bounded_side(q) != CGAL::ON_UNBOUNDED_SIDE;
+    return K::Triangle_2(p[0], p[1], p[2]).bounded_side(q) != CGAL::ON_UNBOUNDED_SIDE;
 }
 } // namespace
 
@@ -127,13 +127,12 @@ Geometry3D::FaceLocation Geometry3D::face_below(const Point3D& p) const
     // above p: a query point sitting exactly on the surface may round minimally
     // below its face's plane, and the strictly-downward ray would miss it.
     constexpr double onSurfaceTolerance = 1e-9;
-    const SurfaceKernel::Ray_3 ray(
-        Point3D{p.x(), p.y(), p.z() + onSurfaceTolerance}, SurfaceKernel::Direction_3(0, 0, -1));
+    const K::Ray_3 ray(Point3D{p.x(), p.y(), p.z() + onSurfaceTolerance}, K::Direction_3(0, 0, -1));
     const auto hit = aabb_tree().first_intersection(ray);
     if(!hit) {
-        return {SurfaceMesh::null_face(), SurfaceKernel::Point_3{}};
+        return {SurfaceMesh::null_face(), K::Point_3{}};
     }
-    const auto* projected = std::get_if<SurfaceKernel::Point_3>(&hit->first);
+    const auto* projected = std::get_if<K::Point_3>(&hit->first);
     // Assert against vertical faces.
     assert(projected && "FATAL: vertical face hit by the face_below line");
     return {hit->second, *projected};
@@ -182,9 +181,8 @@ Geometry3D::FaceLocation
 Geometry3D::locate_in_region(std::size_t region_id, const Point2D& xy) const
 {
     // All intersections along z. Search for the one with the region_id.
-    const SurfaceKernel::Line_3 vertical(
-        Point3D{xy.x(), xy.y(), 0}, SurfaceKernel::Direction_3(0, 0, 1));
-    std::vector<AABBTree::Intersection_and_primitive_id<SurfaceKernel::Line_3>::Type> hits{};
+    const K::Line_3 vertical(Point3D{xy.x(), xy.y(), 0}, K::Direction_3(0, 0, 1));
+    std::vector<AABBTree::Intersection_and_primitive_id<K::Line_3>::Type> hits{};
     aabb_tree().all_intersections(vertical, std::back_inserter(hits));
 
     for(const auto& [where, face] : hits) {
@@ -202,9 +200,8 @@ Geometry3D::locate_in_region(std::size_t region_id, const Point2D& xy) const
 Geometry3D::FaceLocation
 Geometry3D::locate_near_z(const Point2D& xy, double z, double tolerance) const
 {
-    const SurfaceKernel::Line_3 vertical(
-        Point3D{xy.x(), xy.y(), 0}, SurfaceKernel::Direction_3(0, 0, 1));
-    std::vector<AABBTree::Intersection_and_primitive_id<SurfaceKernel::Line_3>::Type> hits{};
+    const K::Line_3 vertical(Point3D{xy.x(), xy.y(), 0}, K::Direction_3(0, 0, 1));
+    std::vector<AABBTree::Intersection_and_primitive_id<K::Line_3>::Type> hits{};
     aabb_tree().all_intersections(vertical, std::back_inserter(hits));
 
     FaceLocation best{SurfaceMesh::null_face(), Point3D{}};

--- a/libsimulator/src/Geometry/Geometry3D.cpp
+++ b/libsimulator/src/Geometry/Geometry3D.cpp
@@ -51,7 +51,7 @@ bool face_covers(const SurfaceMesh& mesh, SurfaceMesh::Face_index f, const Point
         const auto& s = mesh.point(v);
         p[i++] = Point2D{s.x(), s.y()};
     }
-    return K::Triangle_2(p[0], p[1], p[2]).bounded_side(q) != CGAL::ON_UNBOUNDED_SIDE;
+    return Triangle2D(p[0], p[1], p[2]).bounded_side(q) != CGAL::ON_UNBOUNDED_SIDE;
 }
 } // namespace
 
@@ -127,7 +127,7 @@ Geometry3D::FaceLocation Geometry3D::face_below(const Point3D& p) const
     // above p: a query point sitting exactly on the surface may round minimally
     // below its face's plane, and the strictly-downward ray would miss it.
     constexpr double onSurfaceTolerance = 1e-9;
-    const K::Ray_3 ray(Point3D{p.x(), p.y(), p.z() + onSurfaceTolerance}, K::Direction_3(0, 0, -1));
+    const Ray3D ray(Point3D{p.x(), p.y(), p.z() + onSurfaceTolerance}, Direction3D(0, 0, -1));
     const auto hit = aabb_tree().first_intersection(ray);
     if(!hit) {
         return {SurfaceMesh::null_face(), K::Point_3{}};
@@ -181,8 +181,8 @@ Geometry3D::FaceLocation
 Geometry3D::locate_in_region(std::size_t region_id, const Point2D& xy) const
 {
     // All intersections along z. Search for the one with the region_id.
-    const K::Line_3 vertical(Point3D{xy.x(), xy.y(), 0}, K::Direction_3(0, 0, 1));
-    std::vector<AABBTree::Intersection_and_primitive_id<K::Line_3>::Type> hits{};
+    const Line3D vertical(Point3D{xy.x(), xy.y(), 0}, Direction3D(0, 0, 1));
+    std::vector<AABBTree::Intersection_and_primitive_id<Line3D>::Type> hits{};
     aabb_tree().all_intersections(vertical, std::back_inserter(hits));
 
     for(const auto& [where, face] : hits) {
@@ -200,8 +200,8 @@ Geometry3D::locate_in_region(std::size_t region_id, const Point2D& xy) const
 Geometry3D::FaceLocation
 Geometry3D::locate_near_z(const Point2D& xy, double z, double tolerance) const
 {
-    const K::Line_3 vertical(Point3D{xy.x(), xy.y(), 0}, K::Direction_3(0, 0, 1));
-    std::vector<AABBTree::Intersection_and_primitive_id<K::Line_3>::Type> hits{};
+    const Line3D vertical(Point3D{xy.x(), xy.y(), 0}, Direction3D(0, 0, 1));
+    std::vector<AABBTree::Intersection_and_primitive_id<Line3D>::Type> hits{};
     aabb_tree().all_intersections(vertical, std::back_inserter(hits));
 
     FaceLocation best{SurfaceMesh::null_face(), Point3D{}};

--- a/libsimulator/src/Geometry/Geometry3D.hpp
+++ b/libsimulator/src/Geometry/Geometry3D.hpp
@@ -22,7 +22,7 @@ public:
     /// Result of projecting a query point onto the surface along -z.
     struct FaceLocation {
         SurfaceMesh::Face_index face;
-        SurfaceKernel::Point_3 point;
+        K::Point_3 point;
     };
 
     /// Take an already-built surface mesh (e.g. from a mesh builder or a test).

--- a/libsimulator/src/Geometry/RegionSplit.cpp
+++ b/libsimulator/src/Geometry/RegionSplit.cpp
@@ -15,7 +15,6 @@
 
 namespace
 {
-using T2 = K::Triangle_2;
 // The overlap classification must be exact: with inexact constructions,
 // CGAL::intersection has classified a mere vertex touch between two flat
 // slivers as a triangle-shaped overlap (e.g. BUW floorplan), fragmenting a
@@ -24,7 +23,7 @@ using EK = CGAL::Exact_predicates_exact_constructions_kernel;
 using ET2 = EK::Triangle_2;
 
 /// Orthogonal projection of a triangular face onto the x/y-plane (z dropped).
-T2 project(const SurfaceMesh& mesh, SurfaceMesh::Face_index f)
+Triangle2D project(const SurfaceMesh& mesh, SurfaceMesh::Face_index f)
 {
     std::array<Point2D, 3> p{};
     int i = 0;
@@ -32,10 +31,10 @@ T2 project(const SurfaceMesh& mesh, SurfaceMesh::Face_index f)
         const auto& q = mesh.point(v);
         p[i++] = Point2D(q.x(), q.y());
     }
-    return T2(p[0], p[1], p[2]);
+    return Triangle2D(p[0], p[1], p[2]);
 }
 
-ET2 exact(const T2& t)
+ET2 exact(const Triangle2D& t)
 {
     return ET2(
         EK::Point_2(t[0].x(), t[0].y()),
@@ -46,7 +45,7 @@ ET2 exact(const T2& t)
 /// True iff the two projected triangles share a positive-area region. Faces of
 /// one single-valued region only ever touch along shared edges/vertices, whose
 /// intersection is a segment/point -- those are deliberately NOT overlaps.
-bool overlaps(const T2& a, const T2& b)
+bool overlaps(const Triangle2D& a, const Triangle2D& b)
 {
     const auto result = CGAL::intersection(exact(a), exact(b));
     if(!result) {
@@ -90,7 +89,7 @@ RegionSplit split_into_regions(SurfaceMesh& mesh)
 
         // Projected triangles already accepted into this region, each with its
         // 2D bounding box for a cheap overlap pre-filter.
-        std::vector<std::pair<T2, CGAL::Bbox_2>> members{};
+        std::vector<std::pair<Triangle2D, CGAL::Bbox_2>> members{};
         std::queue<SurfaceMesh::Face_index> frontier{};
         const auto join = [&region, id, &members, &frontier, &mesh](SurfaceMesh::Face_index f) {
             region[f] = id;

--- a/libsimulator/src/Geometry/RegionSplit.cpp
+++ b/libsimulator/src/Geometry/RegionSplit.cpp
@@ -15,8 +15,7 @@
 
 namespace
 {
-using P2 = SurfaceKernel::Point_2;
-using T2 = SurfaceKernel::Triangle_2;
+using T2 = K::Triangle_2;
 // The overlap classification must be exact: with inexact constructions,
 // CGAL::intersection has classified a mere vertex touch between two flat
 // slivers as a triangle-shaped overlap (e.g. BUW floorplan), fragmenting a
@@ -27,11 +26,11 @@ using ET2 = EK::Triangle_2;
 /// Orthogonal projection of a triangular face onto the x/y-plane (z dropped).
 T2 project(const SurfaceMesh& mesh, SurfaceMesh::Face_index f)
 {
-    std::array<P2, 3> p{};
+    std::array<Point2D, 3> p{};
     int i = 0;
     for(const auto v : CGAL::vertices_around_face(mesh.halfedge(f), mesh)) {
         const auto& q = mesh.point(v);
-        p[i++] = P2(q.x(), q.y());
+        p[i++] = Point2D(q.x(), q.y());
     }
     return T2(p[0], p[1], p[2]);
 }

--- a/libsimulator/src/Geometry/Validation.cpp
+++ b/libsimulator/src/Geometry/Validation.cpp
@@ -22,9 +22,9 @@ bool IsWalkableNormal(const Vector3& n)
 }
 
 bool IsFaceInMeshPlanar(
-    const CGALMesh& mesh,
-    FaceDescriptor<CGALMesh> face,
-    std::vector<VertexDescriptor<CGALMesh>>& buffer)
+    const SurfaceMesh& mesh,
+    FaceDescriptor<SurfaceMesh> face,
+    std::vector<VertexDescriptor<SurfaceMesh>>& buffer)
 {
     buffer.clear();
     for(auto half_edge : CGAL::halfedges_around_face(CGAL::halfedge(face, mesh), mesh)) {
@@ -48,9 +48,9 @@ bool IsFaceInMeshPlanar(
     });
 }
 
-bool AllFacesInMeshPlanar(const CGALMesh& mesh)
+bool AllFacesInMeshPlanar(const SurfaceMesh& mesh)
 {
-    std::vector<VertexDescriptor<CGALMesh>> buffer{};
+    std::vector<VertexDescriptor<SurfaceMesh>> buffer{};
     buffer.reserve(3);
     return std::all_of(
         std::begin(CGAL::faces(mesh)), std::end(CGAL::faces(mesh)), [&buffer, &mesh](auto face) {
@@ -58,10 +58,10 @@ bool AllFacesInMeshPlanar(const CGALMesh& mesh)
         });
 }
 
-void NormaliseAndValidateMesh(CGALMesh& mesh)
+void NormaliseAndValidateMesh(SurfaceMesh& mesh)
 {
     namespace PMP = CGAL::Polygon_mesh_processing;
-    auto fcc = mesh.add_property_map<CGALMesh::Face_index, size_t>("f:cc").first;
+    auto fcc = mesh.add_property_map<SurfaceMesh::Face_index, size_t>("f:cc").first;
     const auto count = PMP::connected_components(mesh, fcc);
     mesh.remove_property_map(fcc);
     if(count != 1) {

--- a/libsimulator/src/Geometry/Validation.cpp
+++ b/libsimulator/src/Geometry/Validation.cpp
@@ -12,7 +12,7 @@
 #include <numbers>
 #include <vector>
 
-bool IsWalkableNormal(const Vector3& n)
+bool IsWalkableNormal(const Vector3D& n)
 {
     constexpr double max_incline_deg = 50.0;
     constexpr double max_incline_rad = max_incline_deg * std::numbers::pi / 180.0;

--- a/libsimulator/src/Geometry/Validation.hpp
+++ b/libsimulator/src/Geometry/Validation.hpp
@@ -12,7 +12,7 @@
 /// @param n normal vector of the plane to test for walkability
 /// @pre #n needs to be normalized; otherwise the result is not reliable.
 /// @return true if the normal indicates that the plane is walkable.
-bool IsWalkableNormal(const Vector3& n);
+bool IsWalkableNormal(const Vector3D& n);
 
 /// Test if face in mesh is planar.
 /// Degenerate faces (2 or fewer vertices, or all vertices collinear) will return false.

--- a/libsimulator/src/Geometry/Validation.hpp
+++ b/libsimulator/src/Geometry/Validation.hpp
@@ -22,14 +22,14 @@ bool IsWalkableNormal(const Vector3& n);
 ///        IsFaceInMeshPlanar repeatedly to reduce allocations.
 /// @return true if face is planar
 bool IsFaceInMeshPlanar(
-    const CGALMesh& mesh,
-    FaceDescriptor<CGALMesh> face,
-    std::vector<VertexDescriptor<CGALMesh>>& buffer);
+    const SurfaceMesh& mesh,
+    FaceDescriptor<SurfaceMesh> face,
+    std::vector<VertexDescriptor<SurfaceMesh>>& buffer);
 
 /// Test if all faces in the given #mesh are planar.
 /// @param mesh to test.
 /// @return true if all faces are planar
-bool AllFacesInMeshPlanar(const CGALMesh& mesh);
+bool AllFacesInMeshPlanar(const SurfaceMesh& mesh);
 
 /// Validate that the given mesh can be processed by jupedsim.
 /// Ensures the mesh is a single connected component, has no degenerate faces, all faces are
@@ -37,4 +37,4 @@ bool AllFacesInMeshPlanar(const CGALMesh& mesh);
 /// orientations are reversed, i.e. the mesh may be modified.
 /// @param mesh to check
 /// @throws SimulationError with a description of the issue encountered.
-void NormaliseAndValidateMesh(CGALMesh& mesh);
+void NormaliseAndValidateMesh(SurfaceMesh& mesh);

--- a/libsimulator/src/SurfaceMeshShortestPathRoutingEngine.hpp
+++ b/libsimulator/src/SurfaceMeshShortestPathRoutingEngine.hpp
@@ -30,7 +30,7 @@ private:
     const Geometry3D& _geometry;
 
     // cache
-    using Traits = CGAL::Surface_mesh_shortest_path_traits<SurfaceKernel, SurfaceMesh>;
+    using Traits = CGAL::Surface_mesh_shortest_path_traits<K, SurfaceMesh>;
     using ShortestPath = CGAL::Surface_mesh_shortest_path<Traits>;
     std::map<Location, std::unique_ptr<ShortestPath>> _cache{};
 };

--- a/python_bindings_jupedsim/type_casters.hpp
+++ b/python_bindings_jupedsim/type_casters.hpp
@@ -35,7 +35,6 @@ struct type_caster<Point> {
 };
 
 // Point3D <-> tuple[float, float, float]
-// (using SurfaceKernel::Point_3 with EPICK kernel)
 template <>
 struct type_caster<CGAL::Exact_predicates_inexact_constructions_kernel::Point_3> {
     using Point3D = CGAL::Exact_predicates_inexact_constructions_kernel::Point_3;


### PR DESCRIPTION
We use a different kernel for current 2D JuPedSim. In the multi-floor scenario with 3D coordinates, we need a different kernel ("EPICK") due to the SurfaceMeshShortestPath routing. this PR harmonize this to "all EPICK".
In addition, change Point2 to Point2D to make this consistent with Point3D and to express the dimension clearly in the type name itself. For consistency, add Triangle3D, Vector3D, Direction3D, Line3D and Ray3D.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1619/
<!-- PREVIEW-URL-END -->