### PR TITLE
Add the next waypoint to the agent python binding

### DIFF
--- a/docs/source/concepts/routing.rst
+++ b/docs/source/concepts/routing.rst
@@ -337,7 +337,7 @@ It will move towards the specified point and if the point is reached, it will co
 .. code:: python
 
     agent = simulation.agent(direct_steering_agent_id)
-    agent.end_destination = (-10, -10)
+    agent.final_target = (-10, -10)
 
 .. note::
 

--- a/docs/source/concepts/routing.rst
+++ b/docs/source/concepts/routing.rst
@@ -337,7 +337,7 @@ It will move towards the specified point and if the point is reached, it will co
 .. code:: python
 
     agent = simulation.agent(direct_steering_agent_id)
-    agent.target = (-10, -10)
+    agent.end_destination = (-10, -10)
 
 .. note::
 

--- a/libsimulator/src/GenericAgent.hpp
+++ b/libsimulator/src/GenericAgent.hpp
@@ -47,8 +47,8 @@ struct GenericAgent {
     jps::UniqueID<BaseStage> stageId{jps::UniqueID<BaseStage>::Invalid};
 
     // This is evaluated by the "operational level"
-    Point destination{};
-    Point target{};
+    Point nextTarget{};
+    Point endTarget{};
 
     using ModelState = std::variant<
         GeneralizedCentrifugalForceModel::State,
@@ -84,7 +84,7 @@ struct GenericAgent {
         , model(std::move(model_))
     {
         // Position is owned by the model state; seed the initial waypoint from it.
-        target = position();
+        endTarget = position();
     }
 };
 
@@ -135,8 +135,8 @@ struct fmt::formatter<GenericAgent> {
                     agent.id,
                     agent.journeyId,
                     agent.stageId,
-                    agent.destination,
-                    agent.target,
+                    agent.nextTarget,
+                    agent.endTarget,
                     agent.position(),
                     m);
             },

--- a/libsimulator/src/GenericAgent.hpp
+++ b/libsimulator/src/GenericAgent.hpp
@@ -48,7 +48,7 @@ struct GenericAgent {
 
     // This is evaluated by the "operational level"
     Point nextTarget{};
-    Point endTarget{};
+    Point finalTarget{};
 
     using ModelState = std::variant<
         GeneralizedCentrifugalForceModel::State,
@@ -84,7 +84,7 @@ struct GenericAgent {
         , model(std::move(model_))
     {
         // Position is owned by the model state; seed the initial waypoint from it.
-        endTarget = position();
+        finalTarget = position();
     }
 };
 
@@ -136,7 +136,7 @@ struct fmt::formatter<GenericAgent> {
                     agent.journeyId,
                     agent.stageId,
                     agent.nextTarget,
-                    agent.endTarget,
+                    agent.finalTarget,
                     agent.position(),
                     m);
             },

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
@@ -74,7 +74,7 @@ void AnticipationVelocityModel::ComputeNextState(
             return res + NeighborRepulsion(current, neighbor);
         });
 
-    const auto desiredDirection = (current.destination - model.position).Normalized();
+    const auto desiredDirection = (current.nextTarget - model.position).Normalized();
     auto direction = (desiredDirection + neighborRepulsion).Normalized();
     if(direction == Point{}) {
         direction = model.orientation;
@@ -110,7 +110,7 @@ Point AnticipationVelocityModel::UpdateDirection(
     double dt) const
 {
     const auto& model = std::get<State>(ped.model);
-    const Point desiredDirection = (ped.destination - model.position).Normalized();
+    const Point desiredDirection = (ped.nextTarget - model.position).Normalized();
     const Point actualDirection = model.orientation;
     Point updatedDirection;
 
@@ -275,7 +275,7 @@ Point AnticipationVelocityModel::NeighborRepulsion(
 
     // Pedestrian movement and desired directions
     const auto& e1 = model1.orientation;
-    const auto& d1 = (ped1.destination - model1.position).Normalized();
+    const auto& d1 = (ped1.nextTarget - model1.position).Normalized();
     const auto& e2 = model2.orientation;
 
     // Check perception range (Eq. 1)

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
@@ -87,7 +87,7 @@ void CollisionFreeSpeedModel::ComputeNextState(
             return acc + BoundaryRepulsion(current, element);
         });
 
-    const auto desired_direction = (current.destination - model.position).Normalized();
+    const auto desired_direction = (current.nextTarget - model.position).Normalized();
     auto direction = (desired_direction + neighborRepulsion + boundaryRepulsion).Normalized();
     if(direction == Point{}) {
         direction = model.orientation;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
@@ -75,7 +75,7 @@ void CollisionFreeSpeedModelV2::ComputeNextState(
             return acc + BoundaryRepulsion(current, element);
         });
 
-    const auto desired_direction = (current.destination - model.position).Normalized();
+    const auto desired_direction = (current.nextTarget - model.position).Normalized();
     auto direction = (desired_direction + neighborRepulsion + boundaryRepulsion).Normalized();
     if(direction == Point{}) {
         direction = model.orientation;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
@@ -99,7 +99,7 @@ void CollisionFreeSpeedModelV3::ComputeNextState(
             return acc + BoundaryRepulsion(current, element);
         });
 
-    const auto desired_direction = (current.destination - model.position).Normalized();
+    const auto desired_direction = (current.nextTarget - model.position).Normalized();
     auto reference_direction = (desired_direction + boundaryRepulsion).Normalized();
     if(reference_direction == Point{}) {
         reference_direction = model.orientation;

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -71,7 +71,7 @@ void GeneralizedCentrifugalForceModel::ComputeNextState(
     std::optional<Point> velocity{};
     // repulsive forces to the walls and transitions that are not my target
     Point repwall = ForceRepRoom(current, geometry);
-    Point fd = ForceDriv(current, current.destination, model.mass, model.tau, dT, e0);
+    Point fd = ForceDriv(current, current.nextTarget, model.mass, model.tau, dT, e0);
     Point acc = (fd + F_rep + repwall) / model.mass;
 
     velocity = (model.orientation * model.speed) + acc * dT;
@@ -178,7 +178,7 @@ Point GeneralizedCentrifugalForceModel::ForceDriv(
     Point F_driv;
     const auto& model = std::get<State>(ped.model);
     const auto pos = model.position;
-    const auto dest = ped.destination;
+    const auto dest = ped.nextTarget;
     const auto dist = (dest - pos).Norm();
     if(dist > J_EPS_GOAL) {
 

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
@@ -123,7 +123,7 @@ void SocialForceModel::CheckModelConstraint(
 Point SocialForceModel::DrivingForce(const GenericAgent& agent)
 {
     const auto& model = std::get<State>(agent.model);
-    const Point e0 = (agent.destination - model.position).Normalized();
+    const Point e0 = (agent.nextTarget - model.position).Normalized();
     return (e0 * model.desiredSpeed - model.velocity) / model.reactionTime;
 };
 double SocialForceModel::PushingForceLength(double A, double B, double r, double distance)

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
@@ -432,7 +432,7 @@ void WarpDriverModel::ComputeNextState(
     }
 
     // Direction towards destination
-    Point toTarget = current.destination - agentData.position;
+    Point toTarget = current.nextTarget - agentData.position;
     const double distToTarget = toTarget.Norm();
     if(distToTarget < 1e-9) {
         // The old update carried default-initialized stuck/detour state here,

--- a/libsimulator/src/Stage.hpp
+++ b/libsimulator/src/Stage.hpp
@@ -324,7 +324,7 @@ public:
     DirectSteering() = default;
     ~DirectSteering() override = default;
     bool IsCompleted(const GenericAgent&) override { return false; };
-    Point Target(const GenericAgent& agent) override { return agent.target; };
+    Point Target(const GenericAgent& agent) override { return agent.endTarget; };
     StageProxy Proxy(Simulation* simulation) override
     {
         return DirectSteeringProxy(simulation, this);

--- a/libsimulator/src/Stage.hpp
+++ b/libsimulator/src/Stage.hpp
@@ -324,7 +324,7 @@ public:
     DirectSteering() = default;
     ~DirectSteering() override = default;
     bool IsCompleted(const GenericAgent&) override { return false; };
-    Point Target(const GenericAgent& agent) override { return agent.endTarget; };
+    Point Target(const GenericAgent& agent) override { return agent.finalTarget; };
     StageProxy Proxy(Simulation* simulation) override
     {
         return DirectSteeringProxy(simulation, this);

--- a/libsimulator/src/StrategicalDesicionSystem.hpp
+++ b/libsimulator/src/StrategicalDesicionSystem.hpp
@@ -24,7 +24,7 @@ public:
     {
         for(auto& agent : agents) {
             const auto [target, id] = journeys.at(agent.journeyId)->Target(agent);
-            agent.endTarget = target;
+            agent.finalTarget = target;
             stageManager.MigrateAgent(agent.stageId, id);
             agent.stageId = id;
         }

--- a/libsimulator/src/StrategicalDesicionSystem.hpp
+++ b/libsimulator/src/StrategicalDesicionSystem.hpp
@@ -24,7 +24,7 @@ public:
     {
         for(auto& agent : agents) {
             const auto [target, id] = journeys.at(agent.journeyId)->Target(agent);
-            agent.target = target;
+            agent.endTarget = target;
             stageManager.MigrateAgent(agent.stageId, id);
             agent.stageId = id;
         }

--- a/libsimulator/src/TacticalDecisionSystem.hpp
+++ b/libsimulator/src/TacticalDecisionSystem.hpp
@@ -16,7 +16,7 @@ public:
     void Run(RoutingEngine& routingEngine, auto&& agents) const
     {
         for(auto& agent : agents) {
-            const auto dest = agent.endTarget;
+            const auto dest = agent.finalTarget;
             agent.nextTarget = routingEngine.ComputeWaypoint(agent.position(), dest);
         }
     }

--- a/libsimulator/src/TacticalDecisionSystem.hpp
+++ b/libsimulator/src/TacticalDecisionSystem.hpp
@@ -16,8 +16,8 @@ public:
     void Run(RoutingEngine& routingEngine, auto&& agents) const
     {
         for(auto& agent : agents) {
-            const auto dest = agent.target;
-            agent.destination = routingEngine.ComputeWaypoint(agent.position(), dest);
+            const auto dest = agent.endTarget;
+            agent.nextTarget = routingEngine.ComputeWaypoint(agent.position(), dest);
         }
     }
 };

--- a/notebooks/direct_steering.ipynb
+++ b/notebooks/direct_steering.ipynb
@@ -339,7 +339,7 @@
     "            if any(geom.contains(near_leader_point) for geom in area.geoms)\n",
     "            else position_leader\n",
     "        )\n",
-    "        agent.end_target = target\n",
+    "        agent.final_target = target\n",
     "\n",
     "        # Check if the agent reached the exit and mark it for removal if so\n",
     "        if Point(agent.position).distance(exit_area.centroid) < 1:\n",

--- a/notebooks/direct_steering.ipynb
+++ b/notebooks/direct_steering.ipynb
@@ -339,7 +339,7 @@
     "            if any(geom.contains(near_leader_point) for geom in area.geoms)\n",
     "            else position_leader\n",
     "        )\n",
-    "        agent.end_destination = target\n",
+    "        agent.end_target = target\n",
     "\n",
     "        # Check if the agent reached the exit and mark it for removal if so\n",
     "        if Point(agent.position).distance(exit_area.centroid) < 1:\n",

--- a/notebooks/direct_steering.ipynb
+++ b/notebooks/direct_steering.ipynb
@@ -339,7 +339,7 @@
     "            if any(geom.contains(near_leader_point) for geom in area.geoms)\n",
     "            else position_leader\n",
     "        )\n",
-    "        agent.target = target\n",
+    "        agent.end_destination = target\n",
     "\n",
     "        # Check if the agent reached the exit and mark it for removal if so\n",
     "        if Point(agent.position).distance(exit_area.centroid) < 1:\n",

--- a/python_bindings_jupedsim/agent.cpp
+++ b/python_bindings_jupedsim/agent.cpp
@@ -28,10 +28,10 @@ void init_agent(py::module_& m)
         .def_property_readonly(
             "position", [](const GenericAgent& agent) { return intoTuple(agent.position()); })
         .def_property(
-            "end_target",
-            [](const GenericAgent& agent) { return intoTuple(agent.endTarget); },
-            [](GenericAgent& agent, std::tuple<double, double> endTarget) {
-                agent.endTarget = intoPoint(endTarget);
+            "final_target",
+            [](const GenericAgent& agent) { return intoTuple(agent.finalTarget); },
+            [](GenericAgent& agent, std::tuple<double, double> finalTarget) {
+                agent.finalTarget = intoPoint(finalTarget);
             })
         .def_property_readonly(
             "next_target", [](const GenericAgent& agent) { return intoTuple(agent.nextTarget); })

--- a/python_bindings_jupedsim/agent.cpp
+++ b/python_bindings_jupedsim/agent.cpp
@@ -29,12 +29,12 @@ void init_agent(py::module_& m)
             "position", [](const GenericAgent& agent) { return intoTuple(agent.position()); })
         .def_property(
             "end_target",
-            [](const GenericAgent& agent) { return intoTuple(agent.target); },
-            [](GenericAgent& agent, std::tuple<double, double> target) {
-                agent.target = intoPoint(target);
+            [](const GenericAgent& agent) { return intoTuple(agent.endTarget); },
+            [](GenericAgent& agent, std::tuple<double, double> endTarget) {
+                agent.endTarget = intoPoint(endTarget);
             })
         .def_property_readonly(
-            "next", [](const GenericAgent& agent) { return intoTuple(agent.destination); })
+            "next_target", [](const GenericAgent& agent) { return intoTuple(agent.nextTarget); })
         .def_property_readonly(
             "model",
             [](GenericAgent& agent) -> auto& { return agent.model; },

--- a/python_bindings_jupedsim/agent.cpp
+++ b/python_bindings_jupedsim/agent.cpp
@@ -28,11 +28,13 @@ void init_agent(py::module_& m)
         .def_property_readonly(
             "position", [](const GenericAgent& agent) { return intoTuple(agent.position()); })
         .def_property(
-            "target",
+            "end_target",
             [](const GenericAgent& agent) { return intoTuple(agent.target); },
             [](GenericAgent& agent, std::tuple<double, double> target) {
                 agent.target = intoPoint(target);
             })
+        .def_property_readonly(
+            "next", [](const GenericAgent& agent) { return intoTuple(agent.destination); })
         .def_property_readonly(
             "model",
             [](GenericAgent& agent) -> auto& { return agent.model; },

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -133,8 +133,8 @@ class Agent:
         return self.__resolve().position
 
     @property
-    def end_destination(self) -> tuple[float, float]:
-        """Current end destination of the agent.
+    def end_target(self) -> tuple[float, float]:
+        """Current end target of the agent.
 
         Can be used to directly steer an agent towards the given coordinate.
         This will bypass the strategical and tactical level, but the
@@ -152,17 +152,17 @@ class Agent:
             iteration call.
 
         Returns:
-            Current end destination of the agent.
+            Current end target of the agent.
         """
-        return self.__resolve().end_destination
+        return self.__resolve().end_target
 
-    @end_destination.setter
-    def end_destination(self, end_destination: tuple[float, float]) -> None:
-        self.__resolve().end_destination = end_destination
+    @end_target.setter
+    def end_target(self, end_target: tuple[float, float]) -> None:
+        self.__resolve().end_target = end_target
 
     @property
-    def next_destination(self) -> tuple[float, float]:
-        """Current next destination of the agent.
+    def next_target(self) -> tuple[float, float]:
+        """Current next target of the agent.
 
         Next destination is the next waypoint of the current stage of the agent's journey.
         It is used by the operational model to compute the next state of the agent.
@@ -228,14 +228,14 @@ class _TransientAgent:
         return self.__obj.position
 
     @property
-    def end_destination(self) -> tuple[float, float]:
-        """Current end destination of the agent."""
-        return self.__obj.end_destination
+    def end_target(self) -> tuple[float, float]:
+        """Current end target of the agent."""
+        return self.__obj.end_target
 
     @property
-    def next_destination(self) -> tuple[float, float]:
-        """Current next destination of the agent."""
-        return self.__obj.next_destination
+    def next_target(self) -> tuple[float, float]:
+        """Current next target of the agent."""
+        return self.__obj.next_target
 
     @property
     def model(self) -> Any:

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -134,7 +134,7 @@ class Agent:
 
     @property
     def final_target(self) -> tuple[float, float]:
-        """Current end target of the agent.
+        """Current final target of the agent.
 
         Can be used to directly steer an agent towards the given coordinate.
         This will bypass the strategical and tactical level, but the
@@ -152,7 +152,7 @@ class Agent:
             iteration call.
 
         Returns:
-            Current end target of the agent.
+            Current final target of the agent.
         """
         return self.__resolve().final_target
 
@@ -229,7 +229,7 @@ class _TransientAgent:
 
     @property
     def final_target(self) -> tuple[float, float]:
-        """Current end target of the agent."""
+        """Current final target of the agent."""
         return self.__obj.final_target
 
     @property

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -88,7 +88,7 @@ class Agent:
 
     .. code:: python
 
-        agent.target = (1.0, 2.0)
+        agent.end_destination = (1.0, 2.0)
         agent.model.desired_speed = 1.5
 
     .. note ::
@@ -133,8 +133,8 @@ class Agent:
         return self.__resolve().position
 
     @property
-    def target(self) -> tuple[float, float]:
-        """Current target of the agent.
+    def end_destination(self) -> tuple[float, float]:
+        """Current end destination of the agent.
 
         Can be used to directly steer an agent towards the given coordinate.
         This will bypass the strategical and tactical level, but the
@@ -152,13 +152,25 @@ class Agent:
             iteration call.
 
         Returns:
-            Current target of the agent.
+            Current end destination of the agent.
         """
-        return self.__resolve().target
+        return self.__resolve().end_destination
 
-    @target.setter
-    def target(self, target: tuple[float, float]) -> None:
-        self.__resolve().target = target
+    @end_destination.setter
+    def end_destination(self, end_destination: tuple[float, float]) -> None:
+        self.__resolve().end_destination = end_destination
+
+    @property
+    def next_destination(self) -> tuple[float, float]:
+        """Current next destination of the agent.
+
+        Next destination is the next waypoint of the current stage of the agent's journey.
+        It is used by the operational model to compute the next state of the agent.
+
+        Returns:
+            Current next destination of the agent.
+        """
+        return self.__resolve().next_destination
 
     @property
     def model(self) -> Any:
@@ -216,9 +228,14 @@ class _TransientAgent:
         return self.__obj.position
 
     @property
-    def target(self) -> tuple[float, float]:
-        """Current target of the agent."""
-        return self.__obj.target
+    def end_destination(self) -> tuple[float, float]:
+        """Current end destination of the agent."""
+        return self.__obj.end_destination
+
+    @property
+    def next_destination(self) -> tuple[float, float]:
+        """Current next destination of the agent."""
+        return self.__obj.next_destination
 
     @property
     def model(self) -> Any:

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -88,7 +88,7 @@ class Agent:
 
     .. code:: python
 
-        agent.end_destination = (1.0, 2.0)
+        agent.final_target = (1.0, 2.0)
         agent.model.desired_speed = 1.5
 
     .. note ::
@@ -133,7 +133,7 @@ class Agent:
         return self.__resolve().position
 
     @property
-    def end_target(self) -> tuple[float, float]:
+    def final_target(self) -> tuple[float, float]:
         """Current end target of the agent.
 
         Can be used to directly steer an agent towards the given coordinate.
@@ -154,11 +154,11 @@ class Agent:
         Returns:
             Current end target of the agent.
         """
-        return self.__resolve().end_target
+        return self.__resolve().final_target
 
-    @end_target.setter
-    def end_target(self, end_target: tuple[float, float]) -> None:
-        self.__resolve().end_target = end_target
+    @final_target.setter
+    def final_target(self, final_target: tuple[float, float]) -> None:
+        self.__resolve().final_target = final_target
 
     @property
     def next_target(self) -> tuple[float, float]:
@@ -228,9 +228,9 @@ class _TransientAgent:
         return self.__obj.position
 
     @property
-    def end_target(self) -> tuple[float, float]:
+    def final_target(self) -> tuple[float, float]:
         """Current end target of the agent."""
-        return self.__obj.end_target
+        return self.__obj.final_target
 
     @property
     def next_target(self) -> tuple[float, float]:

--- a/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
+++ b/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
@@ -200,8 +200,8 @@ class PythonSocialForceModel(CustomOperationalModel):
 
         # Get target direction (normalized)
         target_diff = (
-            agent.target[0] - agent.position[0],
-            agent.target[1] - agent.position[1],
+            agent.next_destination[0] - agent.position[0],
+            agent.next_destination[1] - agent.position[1],
         )
         # eq 1 in paper
         target_dir = self._normalize(target_diff)

--- a/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
+++ b/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
@@ -200,8 +200,8 @@ class PythonSocialForceModel(CustomOperationalModel):
 
         # Get target direction (normalized)
         target_diff = (
-            agent.next_destination[0] - agent.position[0],
-            agent.next_destination[1] - agent.position[1],
+            agent.next_target[0] - agent.position[0],
+            agent.next_target[1] - agent.position[1],
         )
         # eq 1 in paper
         target_dir = self._normalize(target_diff)

--- a/scripts/ci/gh_build_linux.sh
+++ b/scripts/ci/gh_build_linux.sh
@@ -1,7 +1,6 @@
 set -e
 echo Using ${CC} and ${CXX}
-numcpus=4
-rm -rf build
+numcpus=$(nproc)
 mkdir build && cd build
 cmake  .. -DBUILD_TESTS=ON -DWERROR=ON
 cmake --build . -- -j ${numcpus} -- VERBOSE=1

--- a/scripts/ci/gh_build_linux.sh
+++ b/scripts/ci/gh_build_linux.sh
@@ -1,6 +1,7 @@
 set -e
 echo Using ${CC} and ${CXX}
-numcpus=$(nproc)
+numcpus=4
+rm -rf build
 mkdir build && cd build
 cmake  .. -DBUILD_TESTS=ON -DWERROR=ON
 cmake --build . -- -j ${numcpus} -- VERBOSE=1


### PR DESCRIPTION
Fixes #1625.

The changes include (exceeding the scope of #1625):
- Expose not only the final target, but also the next target of the agent to the Python bindings.
- Rename `target` to `final_target` and `destination` to `next_target` to clarify the meaning. This adds to the readability/clarity of the code.
- Fix the Python SocialForce model implementation as it used `final_target` instead of (the previously non-existing) `next_target`.

It should be noted that exposing `next_target` is only temporary. It is likely that we will change API to have an `orientation` towards the next target, instead of the location itself.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1626/
<!-- PREVIEW-URL-END -->