### PR TITLE
Use Operational Model State in compute next state operation instead of agent

### DIFF
--- a/docs/source/concepts/custom_serialization.rst
+++ b/docs/source/concepts/custom_serialization.rst
@@ -117,7 +117,7 @@ Each :class:`~jupedsim.agent.Agent` exposes:
     * - ``agent.orientation``
       - ``(x, y)`` tuple of the agent's orientation vector
 
-    * - ``agent.model``
+    * - ``agent.state``
       - Model-specific state (speed, radius, etc.)
 
 

--- a/docs/source/migration_2_0.md
+++ b/docs/source/migration_2_0.md
@@ -166,7 +166,7 @@ and write resolves the agent freshly through the simulation:
 ```python
 agent = sim.agent(agent_id)
 agent.target = (10.0, 5.0)
-agent.model.desired_speed = 0.8   # takes effect in the next iterate()
+agent.state.desired_speed = 0.8   # takes effect in the next iterate()
 
 for _ in range(1000):
     sim.iterate()
@@ -174,7 +174,7 @@ for _ in range(1000):
 print(agent.position)             # still valid, freshly resolved
 ```
 
-`agent.model` returns a per-model state handle with the same semantics: it
+`agent.state` returns a per-model state handle with the same semantics: it
 resolves per access and raises once the agent is gone.
 
 ## Mutation during iterate() is now an error

--- a/docs/source/pedestrian_models/collision_free_speed_model_v3.md
+++ b/docs/source/pedestrian_models/collision_free_speed_model_v3.md
@@ -204,7 +204,7 @@ agent_id = sim.add_agent(
 )
 
 # modify at runtime
-sim.agent(agent_id).model.desired_speed = 1.0
+sim.agent(agent_id).state.desired_speed = 1.0
 ```
 
 | Symbol | Parameter (Python) | Default | Unit | Role |

--- a/libsimulator/src/EnvironmentQuery.hpp
+++ b/libsimulator/src/EnvironmentQuery.hpp
@@ -2,10 +2,10 @@
 #pragma once
 
 #include "CollisionGeometry.hpp"
-#include "GenericAgent.hpp"
 #include "GeometricFunctions.hpp"
 #include "LineSegment.hpp"
 #include "NeighborhoodSearch.hpp"
+#include "OperationalModelState.hpp"
 #include "Point.hpp"
 
 #include <algorithm>
@@ -13,8 +13,6 @@
 #include <iterator>
 #include <ranges>
 #include <vector>
-
-using OperationalModelState = GenericAgent::ModelState;
 
 class EnvironmentQuery
 {
@@ -33,18 +31,25 @@ public:
         bool operator()(const Point&) const { return true; }
     };
 
-    // Returns all agents within 'radius' of 'agent', excluding 'agent' itself.
-    // An optional predicate 'filter' further filters the result; it receives the
-    // position for which neighbors are returned as well as the candidates. Example:
-    //   query.AgentsInRange(state, r, [&envQuery, from=model.position](const Point& to) {
-    //   return envQuery.NoGeometryBetween(from, to);})
+    // Returns the model states of all agents within 'radius' of 'state', excluding the agent
+    // with the same position as 'state'. An optional predicate 'filter' further narrows
+    // the result; it receives the candidate's position.
+    // Example:
+    //   envQuery.OtherAgentsInRange(state, r, [&envQuery, from=model.position](const Point& to) {
+    //       return envQuery.NoGeometryBetween(from, to); })
     template <std::predicate<const Point&> Pred = AcceptAll>
-    std::vector<GenericAgent>
+    std::vector<OperationalModelState>
     OtherAgentsInRange(const OperationalModelState& state, double radius, Pred filter = {}) const
     {
-        Point from = Pos(state);
-        return AgentsInRange(
+        const Point from = Position(state);
+        auto agents = AgentsInRange(
             from, radius, [&from, &filter](const Point& to) { return from != to && filter(to); });
+        std::vector<OperationalModelState> states;
+        states.reserve(agents.size());
+        for(auto& a : agents) {
+            states.push_back(std::move(a.state));
+        }
+        return states;
     }
 
     template <std::predicate<const Point&> Pred = AcceptAll>

--- a/libsimulator/src/EnvironmentQuery.hpp
+++ b/libsimulator/src/EnvironmentQuery.hpp
@@ -35,11 +35,13 @@ public:
     // with the same position as 'state'. An optional predicate 'filter' further narrows
     // the result; it receives the candidate's position.
     // Example:
-    //   envQuery.OtherAgentsInRange(state, r, [&envQuery, from=model.position](const Point& to) {
+    //   envQuery.OtherAgentStatesInRange(state, r, [&envQuery, from=state.position](const Point&
+    //   to) {
     //       return envQuery.NoGeometryBetween(from, to); })
     template <std::predicate<const Point&> Pred = AcceptAll>
     std::vector<OperationalModelState>
-    OtherAgentsInRange(const OperationalModelState& state, double radius, Pred filter = {}) const
+    OtherAgentStatesInRange(const OperationalModelState& state, double radius, Pred filter = {})
+        const
     {
         const Point from = Position(state);
         auto agents = AgentsInRange(

--- a/libsimulator/src/GenericAgent.hpp
+++ b/libsimulator/src/GenericAgent.hpp
@@ -1,18 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
-#include "AnticipationVelocityModel.hpp"
-#include "CollisionFreeSpeedModel.hpp"
-#include "CollisionFreeSpeedModelV2.hpp"
-#include "CollisionFreeSpeedModelV3.hpp"
-#include "GeneralizedCentrifugalForceModel.hpp"
-#include "OperationalModel.hpp"
-#include "OperationalModels/CustomModel/CustomModel.hpp"
+#include "OperationalModels/OperationalModelState.hpp"
 #include "OperationalModels/OperationalModelType.hpp"
 #include "Point.hpp"
-#include "SocialForceModel.hpp"
 #include "UniqueID.hpp"
 #include "Visitor.hpp"
-#include "WarpDriver/WarpDriverModel.hpp"
 
 #include <fmt/core.h>
 
@@ -50,53 +42,35 @@ struct GenericAgent {
     Point nextTarget{};
     Point finalTarget{};
 
-    using ModelState = std::variant<
-        GeneralizedCentrifugalForceModel::State,
-        CollisionFreeSpeedModel::State,
-        CollisionFreeSpeedModelV2::State,
-        CollisionFreeSpeedModelV3::State,
-        AnticipationVelocityModel::State,
-        SocialForceModel::State,
-        WarpDriverModel::State,
-        CustomModel::State>;
+    using ModelState = OperationalModelState;
     static_assert(
         EachAlternativeIsModelAgentState<ModelState>,
         "Every agent model state must provide a 'Point position' member");
-    ModelState model{};
+    ModelState state{};
 
     Point& position()
     {
-        return std::visit([](auto& m) -> Point& { return m.position; }, model);
+        return std::visit([](auto& m) -> Point& { return m.position; }, state);
     }
     const Point& position() const
     {
-        return std::visit([](const auto& m) -> const Point& { return m.position; }, model);
+        return std::visit([](const auto& m) -> const Point& { return m.position; }, state);
     }
 
     GenericAgent(
         ID id_,
         jps::UniqueID<Journey> journeyId_,
         jps::UniqueID<BaseStage> stageId_,
-        ModelState model_)
+        ModelState state_)
         : id(id_ != ID::Invalid ? id_ : ID{})
         , journeyId(journeyId_)
         , stageId(stageId_)
-        , model(std::move(model_))
+        , state(std::move(state_))
     {
         // Position is owned by the model state; seed the initial waypoint from it.
         finalTarget = position();
     }
 };
-
-inline const Point& Pos(const GenericAgent::ModelState& state)
-{
-    return std::visit([](const auto& s) -> const Point& { return s.position; }, state);
-}
-
-inline Point& Pos(GenericAgent::ModelState& state)
-{
-    return std::visit([](auto& s) -> Point& { return s.position; }, state);
-}
 
 /// Maps agent model data to the operational model type it belongs to. Kept
 /// exhaustive on purpose: adding a model type will not compile until the
@@ -105,24 +79,24 @@ inline OperationalModelType ModelTypeOf(const GenericAgent::ModelState& model)
 {
     return std::visit(
         overloaded{
-            [](const GeneralizedCentrifugalForceModel::State&) {
+            [](const GeneralizedCentrifugalForceModelState&) {
                 return OperationalModelType::GENERALIZED_CENTRIFUGAL_FORCE;
             },
-            [](const CollisionFreeSpeedModel::State&) {
+            [](const CollisionFreeSpeedModelState&) {
                 return OperationalModelType::COLLISION_FREE_SPEED;
             },
-            [](const CollisionFreeSpeedModelV2::State&) {
+            [](const CollisionFreeSpeedModelV2State&) {
                 return OperationalModelType::COLLISION_FREE_SPEED_V2;
             },
-            [](const CollisionFreeSpeedModelV3::State&) {
+            [](const CollisionFreeSpeedModelV3State&) {
                 return OperationalModelType::COLLISION_FREE_SPEED_V3;
             },
-            [](const AnticipationVelocityModel::State&) {
+            [](const AnticipationVelocityModelState&) {
                 return OperationalModelType::ANTICIPATION_VELOCITY_MODEL;
             },
-            [](const SocialForceModel::State&) { return OperationalModelType::SOCIAL_FORCE; },
-            [](const WarpDriverModel::State&) { return OperationalModelType::WARP_DRIVER; },
-            [](const CustomModel::State&) { return OperationalModelType::CUSTOM_MODEL; }},
+            [](const SocialForceModelState&) { return OperationalModelType::SOCIAL_FORCE; },
+            [](const WarpDriverModelState&) { return OperationalModelType::WARP_DRIVER; },
+            [](const CustomModelState&) { return OperationalModelType::CUSTOM_MODEL; }},
         model);
 }
 
@@ -150,6 +124,6 @@ struct fmt::formatter<GenericAgent> {
                     agent.position(),
                     m);
             },
-            agent.model);
+            agent.state);
     }
 };

--- a/libsimulator/src/OperationalDecisionSystem.hpp
+++ b/libsimulator/src/OperationalDecisionSystem.hpp
@@ -39,7 +39,8 @@ public:
         _next.clear();
         std::copy(std::begin(agents), std::end(agents), std::back_inserter(_next));
         for(size_t index = 0; index < agents.size(); ++index) {
-            _model->ComputeNextState(dT, agents[index], _next[index], envQuery);
+            _model->ComputeNextState(
+                dT, agents[index].state, _next[index].state, agents[index].nextTarget, envQuery);
         }
         // Swap in the computed generation. This is safe because no caller retains
         // pointers/references across an iteration (Python-side agent handles resolve per
@@ -54,6 +55,6 @@ public:
         const CollisionGeometry& geometry) const
     {
         const EnvironmentQuery envQuery{geometry, neighborhoodSearch};
-        _model->CheckModelConstraint(agent, envQuery);
+        _model->CheckModelConstraint(agent.state, envQuery);
     }
 };

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
@@ -2,11 +2,9 @@
 #include "AnticipationVelocityModel.hpp"
 
 #include "EnvironmentQuery.hpp"
-#include "GenericAgent.hpp"
 #include "GeometricFunctions.hpp"
 #include "LineSegment.hpp"
 #include "Macros.hpp"
-#include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 #include "SimulationError.hpp"
@@ -31,64 +29,65 @@ OperationalModelType AnticipationVelocityModel::Type() const
 
 void AnticipationVelocityModel::ComputeNextState(
     double dT,
-    const GenericAgent& current,
-    GenericAgent& next,
+    const OperationalModelState& current,
+    OperationalModelState& next,
+    const Point& destination,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(current.model);
-    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
-    // Exclude occluded and self agents
-    auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
+    const auto& state = std::get<State>(current);
+    const auto& boundary = envQuery.LineSegmentsInRange(state.position);
+    const auto neighborStates = envQuery.OtherAgentsInRange(
+        current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
 
     const auto neighborRepulsion = std::accumulate(
-        std::begin(neighborhood),
-        std::end(neighborhood),
+        std::begin(neighborStates),
+        std::end(neighborStates),
         Point{},
-        [&current, this](const auto& res, const auto& neighbor) {
-            return res + NeighborRepulsion(current, neighbor);
+        [&state, &destination, this](const auto& res, const auto& neighbor) {
+            return res + NeighborRepulsion(state, std::get<State>(neighbor), destination);
         });
 
-    const auto desiredDirection = (current.nextTarget - model.position).Normalized();
+    const auto desiredDirection = (destination - state.position).Normalized();
     auto direction = (desiredDirection + neighborRepulsion).Normalized();
     if(direction == Point{}) {
-        direction = model.orientation;
+        direction = state.orientation;
     }
 
-    const double wallBufferDistance = model.wallBufferDistance;
-    // Wall sliding behavior
-
-    // update direction towards the newly calculated direction
-    direction = UpdateDirection(current, direction, dT);
+    direction = UpdateDirection(state, destination, direction, dT);
     const auto spacing = std::accumulate(
-        std::begin(neighborhood),
-        std::end(neighborhood),
+        std::begin(neighborStates),
+        std::end(neighborStates),
         std::numeric_limits<double>::max(),
-        [&current, &direction, this](const auto& res, const auto& neighbor) {
-            return std::min(res, GetSpacing(current, neighbor, direction));
+        [&state, &direction, this](const auto& res, const auto& neighbor) {
+            return std::min(res, GetSpacing(state, std::get<State>(neighbor), direction));
         });
 
-    const auto optimal_speed = OptimalSpeed(current, spacing, model.timeGap);
+    const auto optimal_speed = OptimalSpeed(state, spacing, state.timeGap);
     direction = HandleWallAvoidance(
-        direction, model.position, model.radius, boundary, wallBufferDistance, _pushoutStrength);
+        direction,
+        state.position,
+        state.radius,
+        boundary,
+        state.wallBufferDistance,
+        _pushoutStrength);
 
     const auto velocity = direction * optimal_speed;
-    auto& nextModel = std::get<State>(next.model);
-    nextModel.position = model.position + velocity * dT;
-    nextModel.orientation = direction;
-    nextModel.velocity = velocity;
-};
+    auto& nextState = std::get<State>(next);
+    nextState.position = state.position + velocity * dT;
+    nextState.orientation = direction;
+    nextState.velocity = velocity;
+}
 
 Point AnticipationVelocityModel::UpdateDirection(
-    const GenericAgent& ped,
+    const State& state,
+    const Point& destination,
     const Point& calculatedDirection,
     double dt) const
 {
-    const auto& model = std::get<State>(ped.model);
-    const Point desiredDirection = (ped.nextTarget - model.position).Normalized();
-    const Point actualDirection = model.orientation;
+    const Point desiredDirection = (destination - state.position).Normalized();
+    const Point actualDirection = state.orientation;
     Point updatedDirection;
 
     if(desiredDirection.ScalarProduct(calculatedDirection) *
@@ -96,9 +95,8 @@ Point AnticipationVelocityModel::UpdateDirection(
        0) {
         updatedDirection = calculatedDirection;
     } else {
-        // Compute the rate of change of direction (Eq. 7)
         const Point directionDerivative =
-            (calculatedDirection.Normalized() - actualDirection) / model.reactionTime;
+            (calculatedDirection.Normalized() - actualDirection) / state.reactionTime;
         updatedDirection = actualDirection + directionDerivative * dt;
     }
 
@@ -106,101 +104,96 @@ Point AnticipationVelocityModel::UpdateDirection(
 }
 
 void AnticipationVelocityModel::CheckModelConstraint(
-    const GenericAgent& agent,
+    const OperationalModelState& generic_state,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(agent.model);
-    const auto r = model.radius;
+    const auto& state = std::get<State>(generic_state);
+    const auto r = state.radius;
     constexpr double rMin = 0.;
     constexpr double rMax = 2.;
     validateConstraint(r, rMin, rMax, "radius", true);
 
-    const auto strengthNeighborRepulsion = model.strengthNeighborRepulsion;
+    const auto strengthNeighborRepulsion = state.strengthNeighborRepulsion;
     constexpr double snMin = 0.;
     constexpr double snMax = 20.;
     validateConstraint(strengthNeighborRepulsion, snMin, snMax, "strengthNeighborRepulsion", false);
 
-    const auto rangeNeighborRepulsion = model.rangeNeighborRepulsion;
+    const auto rangeNeighborRepulsion = state.rangeNeighborRepulsion;
     constexpr double rnMin = 0.;
     constexpr double rnMax = 5.;
     validateConstraint(rangeNeighborRepulsion, rnMin, rnMax, "rangeNeighborRepulsion", true);
 
-    const auto buff = model.wallBufferDistance;
+    const auto buff = state.wallBufferDistance;
     constexpr double buffMin = 0.;
     constexpr double buffMax = 1.;
     validateConstraint(buff, buffMin, buffMax, "wallBufferDistance", false);
 
-    const auto v0 = model.v0;
+    const auto v0 = state.v0;
     constexpr double v0Min = 0.;
     constexpr double v0Max = 10.;
     validateConstraint(v0, v0Min, v0Max, "v0");
 
-    const auto timeGap = model.timeGap;
+    const auto timeGap = state.timeGap;
     constexpr double timeGapMin = 0.;
     constexpr double timeGapMax = 10.;
     validateConstraint(timeGap, timeGapMin, timeGapMax, "timeGap", true);
 
-    const auto anticipationTime = model.anticipationTime;
+    const auto anticipationTime = state.anticipationTime;
     constexpr double anticipationTimeMin = 0.0;
     constexpr double anticipationTimeMax = 5.0;
     validateConstraint(
         anticipationTime, anticipationTimeMin, anticipationTimeMax, "anticipationTime");
 
-    const auto reactionTime = model.reactionTime;
+    const auto reactionTime = state.reactionTime;
     constexpr double reactionTimeMin = 0.0;
     constexpr double reactionTimeMax = 1.0;
     validateConstraint(reactionTime, reactionTimeMin, reactionTimeMax, "reactionTime", true);
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
-        const auto& neighbor_model = std::get<State>(neighbor.model);
-        const auto contanctdDist = r + neighbor_model.radius;
-        const auto distance = (model.position - neighbor_model.position).Norm();
+        const auto& neighbor_state = std::get<State>(neighbor);
+        const auto contanctdDist = r + neighbor_state.radius;
+        const auto distance = (state.position - neighbor_state.position).Norm();
         if(contanctdDist >= distance) {
             throw SimulationError(
                 "Model constraint violation: Agent {} too close to agent {}: distance {}",
-                model.position,
-                neighbor_model.position,
+                state.position,
+                neighbor_state.position,
                 distance);
         }
     }
 
-    const auto lineSegments = envQuery.LineSegmentsInRange(model.position, r);
+    const auto lineSegments = envQuery.LineSegmentsInRange(state.position, r);
     if(std::begin(lineSegments) != std::end(lineSegments)) {
         throw SimulationError(
             "Model constraint violation: Agent {} too close to geometry boundaries, distance "
             "<= {}",
-            model.position,
+            state.position,
             r);
     }
 }
 
-double AnticipationVelocityModel::OptimalSpeed(
-    const GenericAgent& ped,
-    double spacing,
-    double time_gap) const
+double
+AnticipationVelocityModel::OptimalSpeed(const State& state, double spacing, double time_gap) const
 {
-    const auto& model = std::get<State>(ped.model);
     constexpr double creep_speed = 0.01;
 
     double speed = spacing / time_gap;
 
     if(std::abs(speed) < creep_speed) {
-        // Random shuffle: forward, backward, or stop
         const auto r = gen() % 3;
         speed = (r == 0) ? creep_speed : (r == 1) ? -creep_speed : 0.0;
     }
 
-    return std::min(std::max(speed, -creep_speed), model.v0);
+    return std::min(std::max(speed, -creep_speed), state.v0);
 }
+
 double AnticipationVelocityModel::GetSpacing(
-    const GenericAgent& ped1,
-    const GenericAgent& ped2,
+    const State& s1,
+    const State& s2,
     const Point& direction) const
 {
-    const auto& model1 = std::get<State>(ped1.model);
-    const auto& model2 = std::get<State>(ped2.model);
-    const auto distp12 = model2.position - model1.position;
+    const auto distp12 = s2.position - s1.position;
     const auto inFront = direction.ScalarProduct(distp12) >= 0;
     if(!inFront) {
         return std::numeric_limits<double>::max();
@@ -208,7 +201,7 @@ double AnticipationVelocityModel::GetSpacing(
 
     const auto left = direction.Rotate90Deg();
     const auto buffer = 0.02;
-    const auto l = model1.radius + model2.radius + buffer;
+    const auto l = s1.radius + s2.radius + buffer;
     const bool inCorridor = std::abs(left.ScalarProduct(distp12)) <= l;
     if(!inCorridor) {
         return std::numeric_limits<double>::max();
@@ -220,12 +213,10 @@ Point AnticipationVelocityModel::CalculateInfluenceDirection(
     const Point& desiredDirection,
     const Point& predictedDirection) const
 {
-    // Eq. (5)
     const Point orthogonalDirection = Point(-desiredDirection.y, desiredDirection.x).Normalized();
     const double alignment = orthogonalDirection.ScalarProduct(predictedDirection);
     Point influenceDirection = orthogonalDirection;
     if(fabs(alignment) < J_EPS) {
-        // Choose a random direction (left or right)
         if(gen() % 2 == 0) {
             influenceDirection = -orthogonalDirection;
         }
@@ -236,40 +227,33 @@ Point AnticipationVelocityModel::CalculateInfluenceDirection(
 }
 
 Point AnticipationVelocityModel::NeighborRepulsion(
-    const GenericAgent& ped1,
-    const GenericAgent& ped2) const
+    const State& s1,
+    const State& s2,
+    const Point& destination) const
 {
-    const auto& model1 = std::get<State>(ped1.model);
-    const auto& model2 = std::get<State>(ped2.model);
-
-    const auto distp12 = model2.position - model1.position;
+    const auto distp12 = s2.position - s1.position;
     const auto [distance, ep12] = distp12.NormAndNormalized();
-    const double adjustedDist = distance - (model1.radius + model2.radius);
+    const double adjustedDist = distance - (s1.radius + s2.radius);
 
-    // Pedestrian movement and desired directions
-    const auto& e1 = model1.orientation;
-    const auto& d1 = (ped1.nextTarget - model1.position).Normalized();
-    const auto& e2 = model2.orientation;
+    const auto& e1 = s1.orientation;
+    const auto& d1 = (destination - s1.position).Normalized();
+    const auto& e2 = s2.orientation;
 
-    // Check perception range (Eq. 1)
     const auto inPerceptionRange = d1.ScalarProduct(ep12) >= 0 || e1.ScalarProduct(ep12) >= 0;
     if(!inPerceptionRange)
         return Point(0, 0);
 
-    const double S_Gap =
-        (model1.velocity - model2.velocity).ScalarProduct(ep12) * model1.anticipationTime;
+    const double S_Gap = (s1.velocity - s2.velocity).ScalarProduct(ep12) * s1.anticipationTime;
     double R_dist = adjustedDist - S_Gap;
-    R_dist = std::max(R_dist, 0.0); // Clamp to zero if negative
+    R_dist = std::max(R_dist, 0.0);
 
-    // Interaction strength (Eq. 3 & 4)
     constexpr double alignmentBase = 1.0;
     constexpr double alignmentWeight = 0.5;
     const double alignmentFactor = alignmentBase + alignmentWeight * (1.0 - d1.ScalarProduct(e2));
-    const double interactionStrength = model1.strengthNeighborRepulsion * alignmentFactor *
-                                       std::exp(-R_dist / model1.rangeNeighborRepulsion);
-    const auto newep12 = distp12 + model2.velocity * model2.anticipationTime; // e_ij(t+ta)
+    const double interactionStrength = s1.strengthNeighborRepulsion * alignmentFactor *
+                                       std::exp(-R_dist / s1.rangeNeighborRepulsion);
+    const auto newep12 = distp12 + s2.velocity * s2.anticipationTime;
 
-    // Compute adjusted influence direction
     const auto influenceDirection = CalculateInfluenceDirection(d1, newep12);
     return influenceDirection * interactionStrength;
 }
@@ -302,15 +286,10 @@ Point AnticipationVelocityModel::HandleWallAvoidance(
             const auto dotProduct = modifiedDirection.ScalarProduct(normalTowardAgent);
 
             if(dotProduct < 0) {
-                // Direction points into wall - need to project it out
-                // Remove the component pointing into the wall
                 const auto projectedDirection = modifiedDirection - normalTowardAgent * dotProduct;
                 modifiedDirection = projectedDirection + normalTowardAgent * pushoutStrength;
             }
         });
 
-    // Renormalize to maintain speed
-    const auto finalDirection = modifiedDirection.Normalized();
-
-    return finalDirection;
+    return modifiedDirection.Normalized();
 }

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
@@ -36,7 +36,7 @@ void AnticipationVelocityModel::ComputeNextState(
 {
     const auto& state = std::get<State>(current);
     const auto& boundary = envQuery.LineSegmentsInRange(state.position);
-    const auto neighborStates = envQuery.OtherAgentsInRange(
+    const auto neighborStates = envQuery.OtherAgentStatesInRange(
         current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
@@ -149,7 +149,7 @@ void AnticipationVelocityModel::CheckModelConstraint(
     constexpr double reactionTimeMax = 1.0;
     validateConstraint(reactionTime, reactionTimeMin, reactionTimeMax, "reactionTime", true);
 
-    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
+    const auto neighbors = envQuery.OtherAgentStatesInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighbor_state = std::get<State>(neighbor);
         const auto contanctdDist = r + neighbor_state.radius;

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.hpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.hpp
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
+#include "AnticipationVelocityModelState.hpp"
 #include "LineSegment.hpp"
-class EnvironmentQuery;
 #include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 
-#include <fmt/core.h>
+class EnvironmentQuery;
 
 #include <cstdint>
 #include <random>
@@ -16,26 +16,11 @@ class EnvironmentQuery;
 class AnticipationVelocityModel : public OperationalModel
 {
 public:
-    /// Per-agent state of the anticipation velocity model.
-    struct State {
-        Point position{};
-        Point orientation{0.0, 0.0};
-        double strengthNeighborRepulsion{8.0};
-        double rangeNeighborRepulsion{0.1};
-        double wallBufferDistance{0.1}; // buff distance of agent to wall
-        double anticipationTime{1.0}; // anticipation time
-        double reactionTime{0.3}; // reaction time to update direction
-        Point velocity{};
-        double timeGap{1.06};
-        double v0{1.2};
-        double radius{0.2};
-    };
+    using State = AnticipationVelocityModelState;
 
 private:
-    /// Add a small outward component to maintain minimum distance from walls.
     double _pushoutStrength{0.3};
     double _cutOffRadius{3};
-    // Shared sequential RNG: draws must stay on the model to keep simulations deterministic.
     mutable std::mt19937 gen;
 
 public:
@@ -44,20 +29,20 @@ public:
     OperationalModelType Type() const override;
     void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& destination,
         const EnvironmentQuery& envQuery) const override;
-    void CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery)
+    void CheckModelConstraint(const OperationalModelState& state, const EnvironmentQuery& envQuery)
         const override;
 
 private:
-    double OptimalSpeed(const GenericAgent& ped, double spacing, double time_gap) const;
+    double OptimalSpeed(const State& state, double spacing, double time_gap) const;
     Point CalculateInfluenceDirection(
         const Point& desiredDirection,
         const Point& predictedDirection) const;
-    double
-    GetSpacing(const GenericAgent& ped1, const GenericAgent& ped2, const Point& direction) const;
-    Point NeighborRepulsion(const GenericAgent& ped1, const GenericAgent& ped2) const;
+    double GetSpacing(const State& s1, const State& s2, const Point& direction) const;
+    Point NeighborRepulsion(const State& s1, const State& s2, const Point& destination) const;
 
     Point HandleWallAvoidance(
         const Point& direction,
@@ -67,32 +52,9 @@ private:
         double wallBufferDistance,
         double pushoutStrength) const;
 
-    Point
-    UpdateDirection(const GenericAgent& ped, const Point& calculatedDirection, double dt) const;
-};
-
-template <>
-struct fmt::formatter<AnticipationVelocityModel::State> {
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const AnticipationVelocityModel::State& m, FormatContext& ctx) const
-    {
-        return fmt::format_to(
-            ctx.out(),
-            "AnticipationVelocityModel[orientation={}, strengthNeighborRepulsion={}, "
-            "rangeNeighborRepulsion={}, wallBufferDistance={}, "
-            "timeGap={}, v0={}, radius={}, reactionTime={}, anticipationTime={}, velocity={}])",
-            m.orientation,
-            m.strengthNeighborRepulsion,
-            m.rangeNeighborRepulsion,
-            m.wallBufferDistance,
-            m.timeGap,
-            m.v0,
-            m.radius,
-            m.reactionTime,
-            m.anticipationTime,
-            m.velocity);
-    }
+    Point UpdateDirection(
+        const State& state,
+        const Point& destination,
+        const Point& calculatedDirection,
+        double dt) const;
 };

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelState.hpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModelState.hpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "Point.hpp"
+
+#include <fmt/core.h>
+
+struct AnticipationVelocityModelState {
+    Point position{};
+    Point orientation{0.0, 0.0};
+    double strengthNeighborRepulsion{8.0};
+    double rangeNeighborRepulsion{0.1};
+    double wallBufferDistance{0.1};
+    double anticipationTime{1.0};
+    double reactionTime{0.3};
+    Point velocity{};
+    double timeGap{1.06};
+    double v0{1.2};
+    double radius{0.2};
+};
+
+template <>
+struct fmt::formatter<AnticipationVelocityModelState> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const AnticipationVelocityModelState& m, FormatContext& ctx) const
+    {
+        return fmt::format_to(
+            ctx.out(),
+            "AnticipationVelocityModel[orientation={}, strengthNeighborRepulsion={}, "
+            "rangeNeighborRepulsion={}, wallBufferDistance={}, "
+            "timeGap={}, v0={}, radius={}, reactionTime={}, anticipationTime={}, velocity={}])",
+            m.orientation,
+            m.strengthNeighborRepulsion,
+            m.rangeNeighborRepulsion,
+            m.wallBufferDistance,
+            m.timeGap,
+            m.v0,
+            m.radius,
+            m.reactionTime,
+            m.anticipationTime,
+            m.velocity);
+    }
+};

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
@@ -2,17 +2,14 @@
 #include "CollisionFreeSpeedModel.hpp"
 
 #include "EnvironmentQuery.hpp"
-#include "GenericAgent.hpp"
 #include "GeometricFunctions.hpp"
 #include "LineSegment.hpp"
-#include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 #include "SimulationError.hpp"
 
 #include <algorithm>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
 #include <numeric>
 #include <vector>
@@ -36,149 +33,140 @@ OperationalModelType CollisionFreeSpeedModel::Type() const
 
 void CollisionFreeSpeedModel::ComputeNextState(
     double dT,
-    const GenericAgent& current,
-    GenericAgent& next,
+    const OperationalModelState& current,
+    OperationalModelState& next,
+    const Point& destination,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(current.model);
-    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
-    auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
+    const auto& state = std::get<State>(current);
+    const auto& boundary = envQuery.LineSegmentsInRange(state.position);
+    const auto neighborStates = envQuery.OtherAgentsInRange(
+        current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
 
     const auto neighborRepulsion = std::accumulate(
-        std::begin(neighborhood),
-        std::end(neighborhood),
+        std::begin(neighborStates),
+        std::end(neighborStates),
         Point{},
-        [&current, this](const auto& res, const auto& neighbor) {
-            return res + NeighborRepulsion(current, neighbor);
+        [&state, this](const auto& res, const auto& neighbor) {
+            return res + NeighborRepulsion(state, std::get<State>(neighbor));
         });
 
     const auto boundaryRepulsion = std::accumulate(
         std::begin(boundary),
         std::end(boundary),
         Point(0, 0),
-        [this, &current](const auto& acc, const auto& element) {
-            return acc + BoundaryRepulsion(current, element);
+        [this, &state](const auto& acc, const auto& element) {
+            return acc + BoundaryRepulsion(state, element);
         });
 
-    const auto desired_direction = (current.nextTarget - model.position).Normalized();
+    const auto desired_direction = (destination - state.position).Normalized();
     auto direction = (desired_direction + neighborRepulsion + boundaryRepulsion).Normalized();
     if(direction == Point{}) {
-        direction = model.orientation;
+        direction = state.orientation;
     }
     const auto spacing = std::accumulate(
-        std::begin(neighborhood),
-        std::end(neighborhood),
+        std::begin(neighborStates),
+        std::end(neighborStates),
         std::numeric_limits<double>::max(),
-        [&current, &direction, this](const auto& res, const auto& neighbor) {
-            return std::min(res, GetSpacing(current, neighbor, direction));
+        [&state, &direction, this](const auto& res, const auto& neighbor) {
+            return std::min(res, GetSpacing(state, std::get<State>(neighbor), direction));
         });
 
-    const auto optimal_speed = OptimalSpeed(current, spacing, model.timeGap);
+    const auto optimal_speed = OptimalSpeed(state, spacing, state.timeGap);
     const auto velocity = direction * optimal_speed;
-    auto& nextModel = std::get<State>(next.model);
-    nextModel.position = model.position + velocity * dT;
-    nextModel.orientation = direction;
-};
+    auto& nextState = std::get<State>(next);
+    nextState.position = state.position + velocity * dT;
+    nextState.orientation = direction;
+}
 
 void CollisionFreeSpeedModel::CheckModelConstraint(
-    const GenericAgent& agent,
+    const OperationalModelState& generic_state,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(agent.model);
+    const auto& state = std::get<State>(generic_state);
 
-    const auto r = model.radius;
+    const auto r = state.radius;
     constexpr double rMin = 0.;
     constexpr double rMax = 2.;
     validateConstraint(r, rMin, rMax, "radius", true);
 
-    const auto v0 = model.v0;
+    const auto v0 = state.v0;
     constexpr double v0Min = 0.;
     constexpr double v0Max = 10.;
     validateConstraint(v0, v0Min, v0Max, "v0");
 
-    const auto timeGap = model.timeGap;
+    const auto timeGap = state.timeGap;
     constexpr double timeGapMin = 0.1;
     constexpr double timeGapMax = 10.;
     validateConstraint(timeGap, timeGapMin, timeGapMax, "timeGap");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
-        const auto& neighbor_model = std::get<State>(neighbor.model);
-        const auto contanctdDist = r + neighbor_model.radius;
-        const auto distance = (model.position - neighbor_model.position).Norm();
+        const auto& neighbor_state = std::get<State>(neighbor);
+        const auto contanctdDist = r + neighbor_state.radius;
+        const auto distance = (state.position - neighbor_state.position).Norm();
         if(contanctdDist >= distance) {
             throw SimulationError(
                 "Model constraint violation: Agent {} too close to agent {}: distance {}",
-                model.position,
-                neighbor_model.position,
+                state.position,
+                neighbor_state.position,
                 distance);
         }
     }
 
-    const auto lineSegments = envQuery.LineSegmentsInRange(model.position, r);
+    const auto lineSegments = envQuery.LineSegmentsInRange(state.position, r);
     if(std::begin(lineSegments) != std::end(lineSegments)) {
         throw SimulationError(
             "Model constraint violation: Agent {} too close to geometry boundaries, distance "
             "<= {}",
-            model.position,
+            state.position,
             r);
     }
 }
 
-double CollisionFreeSpeedModel::OptimalSpeed(
-    const GenericAgent& ped,
-    double spacing,
-    double time_gap) const
+double
+CollisionFreeSpeedModel::OptimalSpeed(const State& state, double spacing, double time_gap) const
 {
-    const auto& model = std::get<State>(ped.model);
-    return std::min(std::max(spacing / time_gap, 0.0), model.v0);
+    return std::min(std::max(spacing / time_gap, 0.0), state.v0);
 }
 
-double CollisionFreeSpeedModel::GetSpacing(
-    const GenericAgent& ped1,
-    const GenericAgent& ped2,
-    const Point& direction) const
+double
+CollisionFreeSpeedModel::GetSpacing(const State& s1, const State& s2, const Point& direction) const
 {
-    const auto& model1 = std::get<State>(ped1.model);
-    const auto& model2 = std::get<State>(ped2.model);
-    const auto distp12 = model2.position - model1.position;
+    const auto distp12 = s2.position - s1.position;
     const auto inFront = direction.ScalarProduct(distp12) >= 0;
     if(!inFront) {
         return std::numeric_limits<double>::max();
     }
 
     const auto left = direction.Rotate90Deg();
-    const auto l = model1.radius + model2.radius;
+    const auto l = s1.radius + s2.radius;
     bool inCorridor = std::abs(left.ScalarProduct(distp12)) <= l;
     if(!inCorridor) {
         return std::numeric_limits<double>::max();
     }
     return distp12.Norm() - l;
 }
-Point CollisionFreeSpeedModel::NeighborRepulsion(const GenericAgent& ped1, const GenericAgent& ped2)
-    const
+
+Point CollisionFreeSpeedModel::NeighborRepulsion(const State& s1, const State& s2) const
 {
-    const auto& model1 = std::get<State>(ped1.model);
-    const auto& model2 = std::get<State>(ped2.model);
-    const auto distp12 = model2.position - model1.position;
+    const auto distp12 = s2.position - s1.position;
     const auto [distance, direction] = distp12.NormAndNormalized();
-    const auto l = model1.radius + model2.radius;
+    const auto l = s1.radius + s2.radius;
     return direction *
            -(this->strengthNeighborRepulsion * exp((l - distance) / this->rangeNeighborRepulsion));
 }
 
 Point CollisionFreeSpeedModel::BoundaryRepulsion(
-    const GenericAgent& ped,
+    const State& state,
     const LineSegment& boundary_segment) const
 {
-    const auto& model = std::get<State>(ped.model);
-    const auto pt = boundary_segment.ShortestPoint(model.position);
-    const auto dist_vec = pt - model.position;
+    const auto pt = boundary_segment.ShortestPoint(state.position);
+    const auto dist_vec = pt - state.position;
     const auto [dist, e_iw] = dist_vec.NormAndNormalized();
-    const auto l = model.radius;
+    const auto l = state.radius;
     const auto R_iw =
         -this->strengthGeometryRepulsion * exp((l - dist) / this->rangeGeometryRepulsion);
     return e_iw * R_iw;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
@@ -40,7 +40,7 @@ void CollisionFreeSpeedModel::ComputeNextState(
 {
     const auto& state = std::get<State>(current);
     const auto& boundary = envQuery.LineSegmentsInRange(state.position);
-    const auto neighborStates = envQuery.OtherAgentsInRange(
+    const auto neighborStates = envQuery.OtherAgentStatesInRange(
         current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
@@ -102,7 +102,7 @@ void CollisionFreeSpeedModel::CheckModelConstraint(
     constexpr double timeGapMax = 10.;
     validateConstraint(timeGap, timeGapMin, timeGapMax, "timeGap");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
+    const auto neighbors = envQuery.OtherAgentStatesInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighbor_state = std::get<State>(neighbor);
         const auto contanctdDist = r + neighbor_state.radius;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.hpp
@@ -1,26 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
+#include "CollisionFreeSpeedModelState.hpp"
 #include "LineSegment.hpp"
-
-class EnvironmentQuery;
 #include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 
-#include <fmt/core.h>
+class EnvironmentQuery;
 
 class CollisionFreeSpeedModel : public OperationalModel
 {
 public:
-    /// Per-agent state of the collision free speed model.
-    struct State {
-        Point position{};
-        Point orientation{0.0, 0.0};
-        double timeGap{1};
-        double v0{1.2};
-        double radius{0.2};
-    };
+    using State = CollisionFreeSpeedModelState;
 
 private:
     double _cutOffRadius{3};
@@ -39,34 +31,16 @@ public:
     OperationalModelType Type() const override;
     void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& destination,
         const EnvironmentQuery& envQuery) const override;
-    void CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery)
+    void CheckModelConstraint(const OperationalModelState& state, const EnvironmentQuery& envQuery)
         const override;
 
 private:
-    double OptimalSpeed(const GenericAgent& ped, double spacing, double time_gap) const;
-    double
-    GetSpacing(const GenericAgent& ped1, const GenericAgent& ped2, const Point& direction) const;
-    Point NeighborRepulsion(const GenericAgent& ped1, const GenericAgent& ped2) const;
-    Point BoundaryRepulsion(const GenericAgent& ped, const LineSegment& boundary_segment) const;
-};
-
-template <>
-struct fmt::formatter<CollisionFreeSpeedModel::State> {
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const CollisionFreeSpeedModel::State& m, FormatContext& ctx) const
-    {
-        return fmt::format_to(
-            ctx.out(),
-            "CollisionFreeSpeedModel[orientation={}, timeGap={}, v0={}, radius={}])",
-            m.orientation,
-            m.timeGap,
-            m.v0,
-            m.radius);
-    }
+    double OptimalSpeed(const State& state, double spacing, double time_gap) const;
+    double GetSpacing(const State& s1, const State& s2, const Point& direction) const;
+    Point NeighborRepulsion(const State& s1, const State& s2) const;
+    Point BoundaryRepulsion(const State& state, const LineSegment& boundary_segment) const;
 };

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelState.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModelState.hpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "Point.hpp"
+
+#include <fmt/core.h>
+
+struct CollisionFreeSpeedModelState {
+    Point position{};
+    Point orientation{0.0, 0.0};
+    double timeGap{1};
+    double v0{1.2};
+    double radius{0.2};
+};
+
+template <>
+struct fmt::formatter<CollisionFreeSpeedModelState> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const CollisionFreeSpeedModelState& m, FormatContext& ctx) const
+    {
+        return fmt::format_to(
+            ctx.out(),
+            "CollisionFreeSpeedModel[orientation={}, timeGap={}, v0={}, radius={}])",
+            m.orientation,
+            m.timeGap,
+            m.v0,
+            m.radius);
+    }
+};

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
@@ -28,7 +28,7 @@ void CollisionFreeSpeedModelV2::ComputeNextState(
 {
     const auto& state = std::get<State>(current);
     const auto& boundary = envQuery.LineSegmentsInRange(state.position);
-    const auto neighborStates = envQuery.OtherAgentsInRange(
+    const auto neighborStates = envQuery.OtherAgentStatesInRange(
         current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
@@ -90,7 +90,7 @@ void CollisionFreeSpeedModelV2::CheckModelConstraint(
     constexpr double timeGapMax = 10.;
     validateConstraint(timeGap, timeGapMin, timeGapMax, "timeGap");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
+    const auto neighbors = envQuery.OtherAgentStatesInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighbor_state = std::get<State>(neighbor);
         const auto contanctdDist = r + neighbor_state.radius;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
@@ -2,17 +2,14 @@
 #include "CollisionFreeSpeedModelV2.hpp"
 
 #include "EnvironmentQuery.hpp"
-#include "GenericAgent.hpp"
 #include "GeometricFunctions.hpp"
 #include "LineSegment.hpp"
-#include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 #include "SimulationError.hpp"
 
 #include <algorithm>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
 #include <numeric>
 #include <vector>
@@ -24,151 +21,143 @@ OperationalModelType CollisionFreeSpeedModelV2::Type() const
 
 void CollisionFreeSpeedModelV2::ComputeNextState(
     double dT,
-    const GenericAgent& current,
-    GenericAgent& next,
+    const OperationalModelState& current,
+    OperationalModelState& next,
+    const Point& destination,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(current.model);
-    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
-    auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
+    const auto& state = std::get<State>(current);
+    const auto& boundary = envQuery.LineSegmentsInRange(state.position);
+    const auto neighborStates = envQuery.OtherAgentsInRange(
+        current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
 
     const auto neighborRepulsion = std::accumulate(
-        std::begin(neighborhood),
-        std::end(neighborhood),
+        std::begin(neighborStates),
+        std::end(neighborStates),
         Point{},
-        [&current, this](const auto& res, const auto& neighbor) {
-            return res + NeighborRepulsion(current, neighbor);
+        [&state, this](const auto& res, const auto& neighbor) {
+            return res + NeighborRepulsion(state, std::get<State>(neighbor));
         });
 
     const auto boundaryRepulsion = std::accumulate(
         std::begin(boundary),
         std::end(boundary),
         Point(0, 0),
-        [this, &current](const auto& acc, const auto& element) {
-            return acc + BoundaryRepulsion(current, element);
+        [this, &state](const auto& acc, const auto& element) {
+            return acc + BoundaryRepulsion(state, element);
         });
 
-    const auto desired_direction = (current.nextTarget - model.position).Normalized();
+    const auto desired_direction = (destination - state.position).Normalized();
     auto direction = (desired_direction + neighborRepulsion + boundaryRepulsion).Normalized();
     if(direction == Point{}) {
-        direction = model.orientation;
+        direction = state.orientation;
     }
     const auto spacing = std::accumulate(
-        std::begin(neighborhood),
-        std::end(neighborhood),
+        std::begin(neighborStates),
+        std::end(neighborStates),
         std::numeric_limits<double>::max(),
-        [&current, &direction, this](const auto& res, const auto& neighbor) {
-            return std::min(res, GetSpacing(current, neighbor, direction));
+        [&state, &direction, this](const auto& res, const auto& neighbor) {
+            return std::min(res, GetSpacing(state, std::get<State>(neighbor), direction));
         });
 
-    const auto optimal_speed = OptimalSpeed(current, spacing, model.timeGap);
+    const auto optimal_speed = OptimalSpeed(state, spacing, state.timeGap);
     const auto velocity = direction * optimal_speed;
-    auto& nextModel = std::get<State>(next.model);
-    nextModel.position = model.position + velocity * dT;
-    nextModel.orientation = direction;
-};
+    auto& nextState = std::get<State>(next);
+    nextState.position = state.position + velocity * dT;
+    nextState.orientation = direction;
+}
 
 void CollisionFreeSpeedModelV2::CheckModelConstraint(
-    const GenericAgent& agent,
+    const OperationalModelState& generic_state,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(agent.model);
+    const auto& state = std::get<State>(generic_state);
 
-    const auto r = model.radius;
+    const auto r = state.radius;
     constexpr double rMin = 0.;
     constexpr double rMax = 2.;
     validateConstraint(r, rMin, rMax, "radius", true);
 
-    const auto v0 = model.v0;
+    const auto v0 = state.v0;
     constexpr double v0Min = 0.;
     constexpr double v0Max = 10.;
     validateConstraint(v0, v0Min, v0Max, "v0");
 
-    const auto timeGap = model.timeGap;
+    const auto timeGap = state.timeGap;
     constexpr double timeGapMin = 0.1;
     constexpr double timeGapMax = 10.;
     validateConstraint(timeGap, timeGapMin, timeGapMax, "timeGap");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
-        const auto& neighbor_model = std::get<State>(neighbor.model);
-        const auto contanctdDist = r + neighbor_model.radius;
-        const auto distance = (model.position - neighbor_model.position).Norm();
+        const auto& neighbor_state = std::get<State>(neighbor);
+        const auto contanctdDist = r + neighbor_state.radius;
+        const auto distance = (state.position - neighbor_state.position).Norm();
         if(contanctdDist >= distance) {
             throw SimulationError(
                 "Model constraint violation: Agent {} too close to agent {}: distance {}",
-                model.position,
-                neighbor_model.position,
+                state.position,
+                neighbor_state.position,
                 distance);
         }
     }
 
-    const auto lineSegments = envQuery.LineSegmentsInRange(model.position, r);
+    const auto lineSegments = envQuery.LineSegmentsInRange(state.position, r);
     if(std::begin(lineSegments) != std::end(lineSegments)) {
         throw SimulationError(
             "Model constraint violation: Agent {} too close to geometry boundaries, distance "
             "<= {}",
-            model.position,
+            state.position,
             r);
     }
 }
 
-double CollisionFreeSpeedModelV2::OptimalSpeed(
-    const GenericAgent& ped,
-    double spacing,
-    double time_gap) const
+double
+CollisionFreeSpeedModelV2::OptimalSpeed(const State& state, double spacing, double time_gap) const
 {
-    const auto& model = std::get<State>(ped.model);
-    return std::min(std::max(spacing / time_gap, 0.0), model.v0);
+    return std::min(std::max(spacing / time_gap, 0.0), state.v0);
 }
 
 double CollisionFreeSpeedModelV2::GetSpacing(
-    const GenericAgent& ped1,
-    const GenericAgent& ped2,
+    const State& s1,
+    const State& s2,
     const Point& direction) const
 {
-    const auto& model1 = std::get<State>(ped1.model);
-    const auto& model2 = std::get<State>(ped2.model);
-    const auto distp12 = model2.position - model1.position;
+    const auto distp12 = s2.position - s1.position;
     const auto inFront = direction.ScalarProduct(distp12) >= 0;
     if(!inFront) {
         return std::numeric_limits<double>::max();
     }
 
     const auto left = direction.Rotate90Deg();
-    const auto l = model1.radius + model2.radius;
+    const auto l = s1.radius + s2.radius;
     bool inCorridor = std::abs(left.ScalarProduct(distp12)) <= l;
     if(!inCorridor) {
         return std::numeric_limits<double>::max();
     }
     return distp12.Norm() - l;
 }
-Point CollisionFreeSpeedModelV2::NeighborRepulsion(
-    const GenericAgent& ped1,
-    const GenericAgent& ped2) const
+
+Point CollisionFreeSpeedModelV2::NeighborRepulsion(const State& s1, const State& s2) const
 {
-    const auto& model1 = std::get<State>(ped1.model);
-    const auto& model2 = std::get<State>(ped2.model);
-    const auto distp12 = model2.position - model1.position;
+    const auto distp12 = s2.position - s1.position;
     const auto [distance, direction] = distp12.NormAndNormalized();
-    const auto l = model1.radius + model2.radius;
-    return direction * -(model1.strengthNeighborRepulsion *
-                         exp((l - distance) / model1.rangeNeighborRepulsion));
+    const auto l = s1.radius + s2.radius;
+    return direction *
+           -(s1.strengthNeighborRepulsion * exp((l - distance) / s1.rangeNeighborRepulsion));
 }
 
 Point CollisionFreeSpeedModelV2::BoundaryRepulsion(
-    const GenericAgent& ped,
+    const State& state,
     const LineSegment& boundary_segment) const
 {
-    const auto& model = std::get<State>(ped.model);
-    const auto pt = boundary_segment.ShortestPoint(model.position);
-    const auto dist_vec = pt - model.position;
+    const auto pt = boundary_segment.ShortestPoint(state.position);
+    const auto dist_vec = pt - state.position;
     const auto [dist, e_iw] = dist_vec.NormAndNormalized();
-    const auto l = model.radius;
+    const auto l = state.radius;
     const auto R_iw =
-        -model.strengthGeometryRepulsion * exp((l - dist) / model.rangeGeometryRepulsion);
+        -state.strengthGeometryRepulsion * exp((l - dist) / state.rangeGeometryRepulsion);
     return e_iw * R_iw;
 }

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.hpp
@@ -1,31 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
+#include "CollisionFreeSpeedModelV2State.hpp"
 #include "LineSegment.hpp"
-
-class EnvironmentQuery;
 #include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 
-#include <fmt/core.h>
+class EnvironmentQuery;
 
 class CollisionFreeSpeedModelV2 : public OperationalModel
 {
 public:
-    /// Per-agent state of the collision free speed model v2.
-    struct State {
-        Point position{};
-        Point orientation{0.0, 0.0};
-        double strengthNeighborRepulsion{8.0};
-        double rangeNeighborRepulsion{0.1};
-        double strengthGeometryRepulsion{5.0};
-        double rangeGeometryRepulsion{0.02};
-
-        double timeGap{1};
-        double v0{1.2};
-        double radius{0.2};
-    };
+    using State = CollisionFreeSpeedModelV2State;
 
 private:
     double _cutOffRadius{3};
@@ -36,40 +23,16 @@ public:
     OperationalModelType Type() const override;
     void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& destination,
         const EnvironmentQuery& envQuery) const override;
-    void CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery)
+    void CheckModelConstraint(const OperationalModelState& state, const EnvironmentQuery& envQuery)
         const override;
 
 private:
-    double OptimalSpeed(const GenericAgent& ped, double spacing, double time_gap) const;
-    double
-    GetSpacing(const GenericAgent& ped1, const GenericAgent& ped2, const Point& direction) const;
-    Point NeighborRepulsion(const GenericAgent& ped1, const GenericAgent& ped2) const;
-    Point BoundaryRepulsion(const GenericAgent& ped, const LineSegment& boundary_segment) const;
-};
-
-template <>
-struct fmt::formatter<CollisionFreeSpeedModelV2::State> {
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const CollisionFreeSpeedModelV2::State& m, FormatContext& ctx) const
-    {
-        return fmt::format_to(
-            ctx.out(),
-            "CollisionFreeSpeedModelV2[orientation={}, strengthNeighborRepulsion={}, "
-            "rangeNeighborRepulsion={}, strengthGeometryRepulsion={}, rangeGeometryRepulsion={}, "
-            "timeGap={}, v0={}, radius={}])",
-            m.orientation,
-            m.strengthNeighborRepulsion,
-            m.rangeNeighborRepulsion,
-            m.strengthGeometryRepulsion,
-            m.rangeGeometryRepulsion,
-            m.timeGap,
-            m.v0,
-            m.radius);
-    }
+    double OptimalSpeed(const State& state, double spacing, double time_gap) const;
+    double GetSpacing(const State& s1, const State& s2, const Point& direction) const;
+    Point NeighborRepulsion(const State& s1, const State& s2) const;
+    Point BoundaryRepulsion(const State& state, const LineSegment& boundary_segment) const;
 };

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2State.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2State.hpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "Point.hpp"
+
+#include <fmt/core.h>
+
+struct CollisionFreeSpeedModelV2State {
+    Point position{};
+    Point orientation{0.0, 0.0};
+    double strengthNeighborRepulsion{8.0};
+    double rangeNeighborRepulsion{0.1};
+    double strengthGeometryRepulsion{5.0};
+    double rangeGeometryRepulsion{0.02};
+    double timeGap{1};
+    double v0{1.2};
+    double radius{0.2};
+};
+
+template <>
+struct fmt::formatter<CollisionFreeSpeedModelV2State> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const CollisionFreeSpeedModelV2State& m, FormatContext& ctx) const
+    {
+        return fmt::format_to(
+            ctx.out(),
+            "CollisionFreeSpeedModelV2[orientation={}, strengthNeighborRepulsion={}, "
+            "rangeNeighborRepulsion={}, strengthGeometryRepulsion={}, rangeGeometryRepulsion={}, "
+            "timeGap={}, v0={}, radius={}])",
+            m.orientation,
+            m.strengthNeighborRepulsion,
+            m.rangeNeighborRepulsion,
+            m.strengthGeometryRepulsion,
+            m.rangeGeometryRepulsion,
+            m.timeGap,
+            m.v0,
+            m.radius);
+    }
+};

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
@@ -2,10 +2,8 @@
 #include "CollisionFreeSpeedModelV3.hpp"
 
 #include "EnvironmentQuery.hpp"
-#include "GenericAgent.hpp"
 #include "GeometricFunctions.hpp"
 #include "LineSegment.hpp"
-#include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 #include "SimulationError.hpp"
@@ -27,7 +25,7 @@ constexpr double MinReverseSpeed =
     -0.01; // Deterministic tiny reverse floor [m/s] to release local blockages.
 
 double NeighborInfluence(
-    const std::vector<GenericAgent>& neighborhood,
+    const std::vector<OperationalModelState>& neighborhood,
     const Point& pos,
     const Point& reference_direction,
     const CollisionFreeSpeedModelV3::State& model)
@@ -40,8 +38,7 @@ double NeighborInfluence(
     double best_influence = 0.0;
     double best_weight = 0.0;
     for(const auto& neighbor : neighborhood) {
-        const auto relative =
-            std::get<CollisionFreeSpeedModelV3::State>(neighbor.model).position - pos;
+        const auto relative = std::get<CollisionFreeSpeedModelV3::State>(neighbor).position - pos;
         const auto x = reference_direction.ScalarProduct(relative);
         if(x <= 0.0) {
             continue;
@@ -69,14 +66,15 @@ OperationalModelType CollisionFreeSpeedModelV3::Type() const
 
 void CollisionFreeSpeedModelV3::ComputeNextState(
     double dT,
-    const GenericAgent& current,
-    GenericAgent& next,
+    const OperationalModelState& current,
+    OperationalModelState& next,
+    const Point& destination,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(current.model);
-    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
-    auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
+    const auto& state = std::get<State>(current);
+    const auto& boundary = envQuery.LineSegmentsInRange(state.position);
+    const auto neighborStates = envQuery.OtherAgentsInRange(
+        current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
 
@@ -84,20 +82,20 @@ void CollisionFreeSpeedModelV3::ComputeNextState(
         std::begin(boundary),
         std::end(boundary),
         Point(0, 0),
-        [this, &current](const auto& acc, const auto& element) {
-            return acc + BoundaryRepulsion(current, element);
+        [this, &state](const auto& acc, const auto& element) {
+            return acc + BoundaryRepulsion(state, element);
         });
 
-    const auto desired_direction = (current.nextTarget - model.position).Normalized();
+    const auto desired_direction = (destination - state.position).Normalized();
     auto reference_direction = (desired_direction + boundaryRepulsion).Normalized();
     if(reference_direction == Point{}) {
-        reference_direction = model.orientation;
+        reference_direction = state.orientation;
     }
 
     const auto heading_target =
-        NeighborInfluence(neighborhood, model.position, reference_direction, model);
+        NeighborInfluence(neighborStates, state.position, reference_direction, state);
     const auto alpha = std::clamp(dT / TauTheta, 0.0, 1.0);
-    const auto heading_angle = model.headingAngle + alpha * (heading_target - model.headingAngle);
+    const auto heading_angle = state.headingAngle + alpha * (heading_target - state.headingAngle);
     auto direction =
         reference_direction.Rotate(std::cos(heading_angle), std::sin(heading_angle)).Normalized();
     if(direction == Point{}) {
@@ -105,118 +103,113 @@ void CollisionFreeSpeedModelV3::ComputeNextState(
     }
 
     const auto spacing_move = std::accumulate(
-        std::begin(neighborhood),
-        std::end(neighborhood),
+        std::begin(neighborStates),
+        std::end(neighborStates),
         std::numeric_limits<double>::max(),
-        [&current, &direction, this](const auto& res, const auto& neighbor) {
-            return std::min(res, GetSpacing(current, neighbor, direction));
+        [&state, &direction, this](const auto& res, const auto& neighbor) {
+            return std::min(res, GetSpacing(state, std::get<State>(neighbor), direction));
         });
 
     const auto goal_direction =
         (desired_direction == Point{}) ? reference_direction : desired_direction;
     const auto spacing_goal = std::accumulate(
-        std::begin(neighborhood),
-        std::end(neighborhood),
+        std::begin(neighborStates),
+        std::end(neighborStates),
         std::numeric_limits<double>::max(),
-        [&current, &goal_direction, this](const auto& res, const auto& neighbor) {
-            return std::min(res, GetSpacing(current, neighbor, goal_direction));
+        [&state, &goal_direction, this](const auto& res, const auto& neighbor) {
+            return std::min(res, GetSpacing(state, std::get<State>(neighbor), goal_direction));
         });
 
     const auto spacing =
         spacing_move * (1.0 - SpacingBlendWeight) + spacing_goal * SpacingBlendWeight;
 
-    const auto optimal_speed = OptimalSpeed(current, spacing, model.timeGap);
+    const auto optimal_speed = OptimalSpeed(state, spacing, state.timeGap);
     const auto velocity = direction * optimal_speed;
-    auto& nextModel = std::get<State>(next.model);
-    nextModel.position = model.position + velocity * dT;
-    nextModel.orientation = direction;
-    nextModel.headingAngle = heading_angle;
+    auto& nextState = std::get<State>(next);
+    nextState.position = state.position + velocity * dT;
+    nextState.orientation = direction;
+    nextState.headingAngle = heading_angle;
 }
 
 void CollisionFreeSpeedModelV3::CheckModelConstraint(
-    const GenericAgent& agent,
+    const OperationalModelState& generic_state,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(agent.model);
+    const auto& state = std::get<State>(generic_state);
 
-    validateConstraint(model.radius, 0.0, 2.0, "radius", true);
-    validateConstraint(model.v0, 0.0, 10.0, "v0");
-    validateConstraint(model.timeGap, 0.1, 10.0, "timeGap");
+    validateConstraint(state.radius, 0.0, 2.0, "radius", true);
+    validateConstraint(state.v0, 0.0, 10.0, "v0");
+    validateConstraint(state.timeGap, 0.1, 10.0, "timeGap");
 
     validateConstraint(
-        model.strengthNeighborRepulsion,
+        state.strengthNeighborRepulsion,
         0.0,
         std::numeric_limits<double>::max(),
         "strengthNeighborRepulsion");
     validateConstraint(
-        model.rangeNeighborRepulsion,
+        state.rangeNeighborRepulsion,
         0.01,
         std::numeric_limits<double>::max(),
         "rangeNeighborRepulsion");
     validateConstraint(
-        model.strengthGeometryRepulsion,
+        state.strengthGeometryRepulsion,
         0.0,
         std::numeric_limits<double>::max(),
         "strengthGeometryRepulsion");
     validateConstraint(
-        model.rangeGeometryRepulsion,
+        state.rangeGeometryRepulsion,
         0.01,
         std::numeric_limits<double>::max(),
         "rangeGeometryRepulsion");
 
-    validateConstraint(model.rangeXScale, 0.01, std::numeric_limits<double>::max(), "rangeXScale");
-    validateConstraint(model.rangeYScale, 0.01, std::numeric_limits<double>::max(), "rangeYScale");
-    validateConstraint(model.thetaMaxUpperBound, 0.0, std::acos(-1.0), "thetaMaxUpperBound");
-    validateConstraint(model.agentBuffer, 0.0, 100.0, "agentBuffer");
+    validateConstraint(state.rangeXScale, 0.01, std::numeric_limits<double>::max(), "rangeXScale");
+    validateConstraint(state.rangeYScale, 0.01, std::numeric_limits<double>::max(), "rangeYScale");
+    validateConstraint(state.thetaMaxUpperBound, 0.0, std::acos(-1.0), "thetaMaxUpperBound");
+    validateConstraint(state.agentBuffer, 0.0, 100.0, "agentBuffer");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
-        const auto& neighbor_model = std::get<State>(neighbor.model);
-        const auto contactDist = model.radius + neighbor_model.radius;
-        const auto distance = (model.position - neighbor_model.position).Norm();
+        const auto& neighbor_state = std::get<State>(neighbor);
+        const auto contactDist = state.radius + neighbor_state.radius;
+        const auto distance = (state.position - neighbor_state.position).Norm();
         if(contactDist >= distance) {
             throw SimulationError(
                 "Model constraint violation: Agent {} too close to agent {}: distance {}",
-                model.position,
-                neighbor_model.position,
+                state.position,
+                neighbor_state.position,
                 distance);
         }
     }
 
-    const auto lineSegments = envQuery.LineSegmentsInRange(model.position, model.radius);
+    const auto lineSegments = envQuery.LineSegmentsInRange(state.position, state.radius);
     if(std::begin(lineSegments) != std::end(lineSegments)) {
         throw SimulationError(
             "Model constraint violation: Agent {} too close to geometry boundaries, distance "
             "<= {}",
-            model.position,
-            model.radius);
+            state.position,
+            state.radius);
     }
 }
 
-double CollisionFreeSpeedModelV3::OptimalSpeed(
-    const GenericAgent& ped,
-    double spacing,
-    double time_gap) const
+double
+CollisionFreeSpeedModelV3::OptimalSpeed(const State& state, double spacing, double time_gap) const
 {
-    const auto& model = std::get<State>(ped.model);
-    const auto effective_spacing = spacing - model.agentBuffer;
-    return std::min(std::max(effective_spacing / time_gap, MinReverseSpeed), model.v0);
+    const auto effective_spacing = spacing - state.agentBuffer;
+    return std::min(std::max(effective_spacing / time_gap, MinReverseSpeed), state.v0);
 }
 
 double CollisionFreeSpeedModelV3::GetSpacing(
-    const GenericAgent& ped1,
-    const GenericAgent& ped2,
+    const State& s1,
+    const State& s2,
     const Point& direction) const
 {
-    const auto& model1 = std::get<State>(ped1.model);
-    const auto& model2 = std::get<State>(ped2.model);
-    const auto distp12 = model2.position - model1.position;
+    const auto distp12 = s2.position - s1.position;
     if(direction.ScalarProduct(distp12) < 0.0) {
         return std::numeric_limits<double>::max();
     }
 
     const auto left = direction.Rotate90Deg();
-    const auto l = model1.radius + model2.radius;
+    const auto l = s1.radius + s2.radius;
     const auto inCorridor = std::abs(left.ScalarProduct(distp12)) <= l;
     if(!inCorridor) {
         return std::numeric_limits<double>::max();
@@ -226,15 +219,14 @@ double CollisionFreeSpeedModelV3::GetSpacing(
 }
 
 Point CollisionFreeSpeedModelV3::BoundaryRepulsion(
-    const GenericAgent& ped,
+    const State& state,
     const LineSegment& boundary_segment) const
 {
-    const auto& model = std::get<State>(ped.model);
-    const auto pt = boundary_segment.ShortestPoint(model.position);
-    const auto dist_vec = pt - model.position;
+    const auto pt = boundary_segment.ShortestPoint(state.position);
+    const auto dist_vec = pt - state.position;
     const auto [dist, e_iw] = dist_vec.NormAndNormalized();
-    const auto l = model.radius;
+    const auto l = state.radius;
     const auto R_iw =
-        -model.strengthGeometryRepulsion * std::exp((l - dist) / model.rangeGeometryRepulsion);
+        -state.strengthGeometryRepulsion * std::exp((l - dist) / state.rangeGeometryRepulsion);
     return e_iw * R_iw;
 }

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
@@ -73,7 +73,7 @@ void CollisionFreeSpeedModelV3::ComputeNextState(
 {
     const auto& state = std::get<State>(current);
     const auto& boundary = envQuery.LineSegmentsInRange(state.position);
-    const auto neighborStates = envQuery.OtherAgentsInRange(
+    const auto neighborStates = envQuery.OtherAgentStatesInRange(
         current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
@@ -167,7 +167,7 @@ void CollisionFreeSpeedModelV3::CheckModelConstraint(
     validateConstraint(state.thetaMaxUpperBound, 0.0, std::acos(-1.0), "thetaMaxUpperBound");
     validateConstraint(state.agentBuffer, 0.0, 100.0, "agentBuffer");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
+    const auto neighbors = envQuery.OtherAgentStatesInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighbor_state = std::get<State>(neighbor);
         const auto contactDist = state.radius + neighbor_state.radius;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.hpp
@@ -1,37 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
+#include "CollisionFreeSpeedModelV3State.hpp"
 #include "LineSegment.hpp"
-
-class EnvironmentQuery;
 #include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 
-#include <fmt/core.h>
+class EnvironmentQuery;
 
 class CollisionFreeSpeedModelV3 : public OperationalModel
 {
 public:
-    /// Per-agent state of the collision free speed model v3.
-    struct State {
-        Point position{};
-        Point orientation{1.0, 0.0};
-        double strengthNeighborRepulsion{8.0}; // [rad] max steering authority before upper bound
-        double rangeNeighborRepulsion{0.1}; // [m] base interaction range for neighbor influence
-        double strengthGeometryRepulsion{5.0}; // [-] wall repulsion strength
-        double rangeGeometryRepulsion{0.02}; // [m] wall repulsion decay length
-
-        double rangeXScale{20.0}; // [-] forward interaction stretch multiplier
-        double rangeYScale{8.0}; // [-] lateral interaction stretch multiplier
-        double thetaMaxUpperBound{1.57}; // [rad] hard cap on turn angle per update
-        double agentBuffer{0.0}; // [m] stand-off used in speed law: v=0 at s<=buffer
-
-        double timeGap{1};
-        double v0{1.2};
-        double radius{0.2};
-        double headingAngle{0.0}; // [rad] persistent relaxed heading state
-    };
+    using State = CollisionFreeSpeedModelV3State;
 
 private:
     double _cutOffRadius{3};
@@ -42,45 +23,15 @@ public:
     OperationalModelType Type() const override;
     void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& destination,
         const EnvironmentQuery& envQuery) const override;
-    void CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery)
+    void CheckModelConstraint(const OperationalModelState& state, const EnvironmentQuery& envQuery)
         const override;
 
 private:
-    double OptimalSpeed(const GenericAgent& ped, double spacing, double time_gap) const;
-    double
-    GetSpacing(const GenericAgent& ped1, const GenericAgent& ped2, const Point& direction) const;
-    Point BoundaryRepulsion(const GenericAgent& ped, const LineSegment& boundary_segment) const;
-};
-
-template <>
-struct fmt::formatter<CollisionFreeSpeedModelV3::State> {
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const CollisionFreeSpeedModelV3::State& m, FormatContext& ctx) const
-    {
-        return fmt::format_to(
-            ctx.out(),
-            "CollisionFreeSpeedModelV3[orientation={}, strengthNeighborRepulsion={}, "
-            "rangeNeighborRepulsion={}, strengthGeometryRepulsion={}, rangeGeometryRepulsion={}, "
-            "rangeXScale={}, rangeYScale={}, thetaMaxUpperBound={}, agentBuffer={}, "
-            "timeGap={}, v0={}, radius={}, headingAngle={}])",
-            m.orientation,
-            m.strengthNeighborRepulsion,
-            m.rangeNeighborRepulsion,
-            m.strengthGeometryRepulsion,
-            m.rangeGeometryRepulsion,
-            m.rangeXScale,
-            m.rangeYScale,
-            m.thetaMaxUpperBound,
-            m.agentBuffer,
-            m.timeGap,
-            m.v0,
-            m.radius,
-            m.headingAngle);
-    }
+    double OptimalSpeed(const State& state, double spacing, double time_gap) const;
+    double GetSpacing(const State& s1, const State& s2, const Point& direction) const;
+    Point BoundaryRepulsion(const State& state, const LineSegment& boundary_segment) const;
 };

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3State.hpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3State.hpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "Point.hpp"
+
+#include <fmt/core.h>
+
+struct CollisionFreeSpeedModelV3State {
+    Point position{};
+    Point orientation{1.0, 0.0};
+    double strengthNeighborRepulsion{8.0};
+    double rangeNeighborRepulsion{0.1};
+    double strengthGeometryRepulsion{5.0};
+    double rangeGeometryRepulsion{0.02};
+    double rangeXScale{20.0};
+    double rangeYScale{8.0};
+    double thetaMaxUpperBound{1.57};
+    double agentBuffer{0.0};
+    double timeGap{1};
+    double v0{1.2};
+    double radius{0.2};
+    double headingAngle{0.0};
+};
+
+template <>
+struct fmt::formatter<CollisionFreeSpeedModelV3State> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const CollisionFreeSpeedModelV3State& m, FormatContext& ctx) const
+    {
+        return fmt::format_to(
+            ctx.out(),
+            "CollisionFreeSpeedModelV3[orientation={}, strengthNeighborRepulsion={}, "
+            "rangeNeighborRepulsion={}, strengthGeometryRepulsion={}, rangeGeometryRepulsion={}, "
+            "rangeXScale={}, rangeYScale={}, thetaMaxUpperBound={}, agentBuffer={}, "
+            "timeGap={}, v0={}, radius={}, headingAngle={}])",
+            m.orientation,
+            m.strengthNeighborRepulsion,
+            m.rangeNeighborRepulsion,
+            m.strengthGeometryRepulsion,
+            m.rangeGeometryRepulsion,
+            m.rangeXScale,
+            m.rangeYScale,
+            m.thetaMaxUpperBound,
+            m.agentBuffer,
+            m.timeGap,
+            m.v0,
+            m.radius,
+            m.headingAngle);
+    }
+};

--- a/libsimulator/src/OperationalModels/CustomModel/CustomModel.hpp
+++ b/libsimulator/src/OperationalModels/CustomModel/CustomModel.hpp
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "FormatAny.hpp"
+#include "CustomModelState.hpp"
 #include "OperationalModel.hpp"
 #include "Point.hpp"
-
-#include <any>
-#include <type_traits>
-#include <utility>
 
 /// Base class for operational models implemented outside libsimulator.
 ///
@@ -17,14 +13,10 @@
 /// type to OperationalModelType::CUSTOM_MODEL so custom models do not need to repeat that
 /// boilerplate.
 ///
-/// Per-agent custom state should be stored in GenericAgent::model as CustomModel::State. In
-/// ComputeNextState(), "next" arrives as an exact copy of "current"; the model overwrites only the
-/// fields it changes. The agent's new position must be written to CustomModel::State::position of
-/// "next". CustomModel::State stores its payload in std::any, so model implementations must agree
-/// on the concrete stored type and retrieve it with the exact typed accessors.
-///
-/// Payload types must be copy-constructible because GenericAgent values are copied during
-/// simulation queries, e.g. by NeighborhoodSearch.
+/// Per-agent custom state is stored as CustomModel::State (alias for CustomModelState) inside the
+/// OperationalModelState variant. In ComputeNextState(), "next" arrives as an exact copy of
+/// "current"; the model overwrites only the fields it changes. The agent's new position must be
+/// written to State::position of "next".
 ///
 /// @code
 /// class MyModel : public CustomModel
@@ -32,12 +24,13 @@
 /// public:
 ///     void ComputeNextState(
 ///         double dT,
-///         const GenericAgent& current,
-///         GenericAgent& next,
+///         const OperationalModelState& current,
+///         OperationalModelState& next,
+///         const Point& destination,
 ///         const EnvironmentQuery& envQuery) const override;
 ///
 ///     void CheckModelConstraint(
-///         const GenericAgent& agent,
+///         const OperationalModelState& state,
 ///         const EnvironmentQuery& envQuery) const override;
 /// };
 /// @endcode
@@ -47,82 +40,10 @@
 class CustomModel : public OperationalModel
 {
 public:
-    /// Type-erased per-agent state for CustomModel implementations.
-    ///
-    /// CustomModel::State lets a custom operational model store model-specific state in
-    /// GenericAgent::model without adding a new built-in model data type. The payload is stored
-    /// by value in std::any so custom state follows the same ownership model as built-in agent
-    /// model state.
-    ///
-    /// Payload types must be copy-constructible. GenericAgent values are copied by parts of the
-    /// simulation, for example by neighborhood queries, so custom state must remain valid under
-    /// normal value-copy semantics.
-    ///
-    /// Access is runtime-typed: Get<T>() must use the exact stored type T. A type mismatch
-    /// throws std::bad_any_cast.
-    ///
-    /// Formatting is best-effort. If the payload has a fmt formatter, that is used. Otherwise,
-    /// if it provides a public ToString() callable on const T& and returning std::string,
-    /// std::string_view, or const char*, ToString() is used. If neither is available, formatting
-    /// falls back to a diagnostic <type@address> representation.
-    class State
-    {
-    public:
-        /// State position cache, kept outside the type-erased payload so the framework can read
-        /// it without touching the payload (for GilSafePyObject payloads: without acquiring the
-        /// GIL). The owning model must keep it in sync with the payload's own position state.
-        Point position{};
-
-    private:
-        std::any value{};
-        FormatFn format{};
-
-    public:
-        template <typename T>
-            requires(!std::is_same_v<std::decay_t<T>, State>)
-        State(T&& value) : value(std::forward<T>(value)), format(makeFormatFn<T>())
-        {
-            using Stored = std::decay_t<T>;
-            static_assert(
-                std::is_copy_constructible_v<Stored>,
-                "CustomModel::State payloads must be copy-constructible");
-        }
-
-        template <typename T>
-        T& Get()
-        {
-            return std::any_cast<T&>(value);
-        }
-
-        template <typename T>
-        const T& Get() const
-        {
-            return std::any_cast<const T&>(value);
-        }
-
-        template <typename T>
-        void Set(T&& newValue)
-        {
-            using Stored = std::decay_t<T>;
-            std::any_cast<Stored&>(value) = std::forward<T>(newValue);
-        }
-
-        friend struct fmt::formatter<State>;
-    };
+    using State = CustomModelState;
 
     CustomModel() = default;
     ~CustomModel() override = default;
 
     OperationalModelType Type() const override { return OperationalModelType::CUSTOM_MODEL; }
-};
-
-template <>
-struct fmt::formatter<CustomModel::State> {
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    auto format(const CustomModel::State& value, fmt::format_context& ctx) const
-    {
-        return value.format(value.value, ctx);
-    }
 };

--- a/libsimulator/src/OperationalModels/CustomModel/CustomModelState.hpp
+++ b/libsimulator/src/OperationalModels/CustomModel/CustomModelState.hpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "FormatAny.hpp"
+#include "Point.hpp"
+
+#include <fmt/core.h>
+
+#include <any>
+#include <type_traits>
+#include <utility>
+
+class CustomModelState
+{
+public:
+    /// Position cache kept outside the type-erased payload so the framework can read it
+    /// without touching the payload (e.g. without acquiring the GIL for Python objects).
+    /// The owning model must keep it in sync with the payload's own position field.
+    Point position{};
+
+private:
+    std::any value{};
+    FormatFn format{};
+
+public:
+    template <typename T>
+        requires(!std::is_same_v<std::decay_t<T>, CustomModelState>)
+    CustomModelState(T&& value) : value(std::forward<T>(value)), format(makeFormatFn<T>())
+    {
+        using Stored = std::decay_t<T>;
+        static_assert(
+            std::is_copy_constructible_v<Stored>,
+            "CustomModelState payloads must be copy-constructible");
+    }
+
+    template <typename T>
+    T& Get()
+    {
+        return std::any_cast<T&>(value);
+    }
+
+    template <typename T>
+    const T& Get() const
+    {
+        return std::any_cast<const T&>(value);
+    }
+
+    template <typename T>
+    void Set(T&& newValue)
+    {
+        using Stored = std::decay_t<T>;
+        std::any_cast<Stored&>(value) = std::forward<T>(newValue);
+    }
+
+    friend struct fmt::formatter<CustomModelState>;
+};
+
+template <>
+struct fmt::formatter<CustomModelState> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const CustomModelState& value, fmt::format_context& ctx) const
+    {
+        return value.format(value.value, ctx);
+    }
+};

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -3,17 +3,15 @@
 
 #include "Ellipse.hpp"
 #include "EnvironmentQuery.hpp"
-#include "GenericAgent.hpp"
 #include "Macros.hpp"
 #include "Mathematics.hpp"
-#include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Simulation.hpp"
 #include "SimulationError.hpp"
 
 #include <Logger.hpp>
 
-#include <optional>
+#include <numeric>
 #include <stdexcept>
 
 GeneralizedCentrifugalForceModel::GeneralizedCentrifugalForceModel(
@@ -43,120 +41,112 @@ OperationalModelType GeneralizedCentrifugalForceModel::Type() const
 
 void GeneralizedCentrifugalForceModel::ComputeNextState(
     double dT,
-    const GenericAgent& current,
-    GenericAgent& next,
+    const OperationalModelState& current,
+    OperationalModelState& next,
+    const Point& destination,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(current.model);
-    auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
+    const auto& state = std::get<State>(current);
+    const auto neighborStates = envQuery.OtherAgentsInRange(
+        current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
+
     Point F_rep;
-    for(const auto& neighbor : neighborhood) {
-        F_rep += ForceRepPed(current, neighbor);
+    for(const auto& neighbor : neighborStates) {
+        F_rep += ForceRepPed(state, std::get<State>(neighbor));
     }
 
-    // e0 stays default constructed when ForceDriv does not overwrite it, matching the old
-    // update struct semantics.
     Point e0{};
-    std::optional<Point> position{};
-    std::optional<Point> velocity{};
-    // repulsive forces to the walls and transitions that are not my target
-    Point repwall = ForceRepRoom(current, envQuery);
-    Point fd = ForceDriv(current, current.nextTarget, model.mass, model.tau, dT, e0);
-    Point acc = (fd + F_rep + repwall) / model.mass;
+    Point repwall = ForceRepRoom(state, envQuery);
+    Point fd = ForceDriv(state, destination, state.mass, state.tau, dT, e0);
+    Point acc = (fd + F_rep + repwall) / state.mass;
 
-    velocity = (model.orientation * model.speed) + acc * dT;
-    position = model.position + *velocity * dT;
+    const Point velocity = (state.orientation * state.speed) + acc * dT;
+    const Point position = state.position + velocity * dT;
 
-    auto& nextModel = std::get<State>(next.model);
-    nextModel.e0 = e0;
-    ++nextModel.orientationDelay;
-    if(position) {
-        nextModel.position = *position;
-    }
-    if(velocity) {
-        nextModel.orientation = (*velocity).Normalized();
-        nextModel.speed = (*velocity).Norm();
-    }
+    auto& nextState = std::get<State>(next);
+    nextState.e0 = e0;
+    ++nextState.orientationDelay;
+    nextState.position = position;
+    nextState.orientation = velocity.Normalized();
+    nextState.speed = velocity.Norm();
 }
 
 void GeneralizedCentrifugalForceModel::CheckModelConstraint(
-    const GenericAgent& agent,
+    const OperationalModelState& generic_state,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(agent.model);
+    const auto& state = std::get<State>(generic_state);
 
-    if(!model.orientation.IsUnitLength()) {
-        throw SimulationError("Orientation is invalid: {}. Length should be 1.", model.orientation);
+    if(!state.orientation.IsUnitLength()) {
+        throw SimulationError("Orientation is invalid: {}. Length should be 1.", state.orientation);
     }
 
-    const auto mass = model.mass;
+    const auto mass = state.mass;
     constexpr double massMin = 1.;
     constexpr double massMax = 100.;
     validateConstraint(mass, massMin, massMax, "mass");
 
-    const auto tau = model.tau;
+    const auto tau = state.tau;
     constexpr double tauMin = 0.1;
     constexpr double tauMax = 10.;
     validateConstraint(tau, tauMin, tauMax, "tau");
 
-    const auto v0 = model.v0;
+    const auto v0 = state.v0;
     constexpr double v0Min = 0.;
     constexpr double v0Max = 10.;
     validateConstraint(v0, v0Min, v0Max, "v0");
 
-    const auto Av = model.Av;
+    const auto Av = state.Av;
     constexpr double AvMin = 0.;
     constexpr double AvMax = 10.;
     validateConstraint(Av, AvMin, AvMax, "Av");
 
-    const auto AMin = model.AMin;
+    const auto AMin = state.AMin;
     constexpr double AMinMin = 0.1;
     constexpr double AMinMax = 1.;
     validateConstraint(AMin, AMinMin, AMinMax, "AMin");
 
-    const auto BMin = model.BMin;
+    const auto BMin = state.BMin;
     constexpr double BMinMin = 0.1;
     constexpr double BMinMax = 1.;
     validateConstraint(BMin, BMinMin, BMinMax, "BMin");
 
-    const auto BMax = model.BMax;
+    const auto BMax = state.BMax;
     const double BMaxMin = BMin;
     constexpr double BMaxMax = 2.;
     validateConstraint(BMax, BMaxMin, BMaxMax, "BMax");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
-        const auto& neighborModel = std::get<State>(neighbor.model);
-        const auto contanctDist = AgentToAgentSpacing(agent, neighbor);
-        const auto distance = (model.position - neighborModel.position).Norm();
+        const auto& neighborState = std::get<State>(neighbor);
+        const auto contanctDist = AgentToAgentSpacing(state, neighborState);
+        const auto distance = (state.position - neighborState.position).Norm();
         if(contanctDist >= distance) {
             throw SimulationError(
                 "Model constraint violation: Agent {} too close to agent {}: distance {}, "
-                "contactDist {}, "
-                "effective distance {}",
-                model.position,
-                neighborModel.position,
+                "contactDist {}, effective distance {}",
+                state.position,
+                neighborState.position,
                 distance,
                 contanctDist,
                 distance - contanctDist);
         }
     }
 
-    const auto maxRadius = std::max(AMin, BMax) / 2.;
-    const auto lineSegments = envQuery.LineSegmentsInRange(model.position, maxRadius);
+    const auto maxRadius = std::max(state.AMin, state.BMax) / 2.;
+    const auto lineSegments = envQuery.LineSegmentsInRange(state.position, maxRadius);
     if(std::begin(lineSegments) != std::end(lineSegments)) {
         throw SimulationError(
             "Model constraint violation: Agent {} too close to geometry boundaries, distance <= {}",
-            model.position,
+            state.position,
             maxRadius);
     }
 }
 
 Point GeneralizedCentrifugalForceModel::ForceDriv(
-    const GenericAgent& ped,
+    const State& state,
     Point target,
     double mass,
     double tau,
@@ -164,86 +154,65 @@ Point GeneralizedCentrifugalForceModel::ForceDriv(
     Point& e0update) const
 {
     Point F_driv;
-    const auto& model = std::get<State>(ped.model);
-    const auto pos = model.position;
-    const auto dest = ped.nextTarget;
-    const auto dist = (dest - pos).Norm();
+    const auto pos = state.position;
+    const auto dist = (target - pos).Norm();
     if(dist > J_EPS_GOAL) {
-
-        const Point e0 = mollify_e0(target, pos, deltaT, model.orientationDelay, model.e0);
+        const Point e0 = mollify_e0(target, pos, deltaT, state.orientationDelay, state.e0);
         e0update = e0;
-        F_driv = ((e0 * model.v0 - (model.orientation * model.speed)) * mass) / tau;
+        F_driv = ((e0 * state.v0 - (state.orientation * state.speed)) * mass) / tau;
     } else {
-        const Point e0 = model.e0;
-        F_driv = ((e0 * model.v0 - (model.orientation * model.speed)) * mass) / tau;
+        const Point e0 = state.e0;
+        F_driv = ((e0 * state.v0 - (state.orientation * state.speed)) * mass) / tau;
     }
     return F_driv;
 }
 
-Point GeneralizedCentrifugalForceModel::ForceRepPed(
-    const GenericAgent& ped1,
-    const GenericAgent& ped2) const
+Point GeneralizedCentrifugalForceModel::ForceRepPed(const State& s1, const State& s2) const
 {
-    const auto& model1 = std::get<State>(ped1.model);
-    const auto& model2 = std::get<State>(ped2.model);
     Point F_rep;
-    // x- and y-coordinate of the distance between p1 and p2
-    Point distp12 = model2.position - model1.position;
-    const Point vp1 = (model1.orientation * model1.speed); // v Ped1
-    const Point vp2 = (model2.orientation * model2.speed); // v Ped2
-    Point ep12; // x- and y-coordinate of the normalized vector between p1 and p2
+    Point distp12 = s2.position - s1.position;
+    const Point vp1 = (s1.orientation * s1.speed);
+    const Point vp2 = (s2.orientation * s2.speed);
+    Point ep12;
     double tmp, tmp2;
     double v_ij;
     double K_ij;
-    double nom; // nominator of Frep
-    double px; // hermite Interpolation value
-    const auto dist_eff = AgentToAgentSpacing(ped1, ped2);
-    const auto agent1_mass = model1.mass;
+    double nom;
+    double px;
+    const auto dist_eff = AgentToAgentSpacing(s1, s2);
+    const auto agent1_mass = s1.mass;
 
-    //          smax    dist_intpol_left      dist_intpol_right       dist_eff_max
-    //       ----|-------------|--------------------------|--------------|----
-    //       5   |     4       |            3             |      2       | 1
-
-    // If the pedestrian is outside the cutoff distance, the force is zero.
     if(dist_eff >= maxNeighborInteractionDistance) {
         F_rep = Point(0.0, 0.0);
         return F_rep;
     }
 
-    const double mindist =
-        0.5; // for performance reasons, it is assumed that this distance is about 50 cm
-    const double dist_intpol_left =
-        mindist + maxNeighborInterpolationDistance; // lower cut-off for Frep (modCFM)
+    const double mindist = 0.5;
+    const double dist_intpol_left = mindist + maxNeighborInterpolationDistance;
     const double dist_intpol_right =
-        maxNeighborInteractionDistance -
-        maxNeighborInterpolationDistance; // upper cut-off for Frep (modCFM)
-    const double smax = mindist - maxNeighborInterpolationDistance; // max overlapping
-    double f = 0.0f; // fuction value
-    double f1 = 0.0f; // derivative of function value
+        maxNeighborInteractionDistance - maxNeighborInterpolationDistance;
+    const double smax = mindist - maxNeighborInterpolationDistance;
+    double f = 0.0f;
+    double f1 = 0.0f;
 
-    // todo: runtime normsquare?
     if(distp12.Norm() >= J_EPS) {
         ep12 = distp12.Normalized();
-
     } else {
         LOG_WARNING(
             "Distance between two pedestrians is small ({}<{}). Force can not be calculated.",
             distp12.Norm(),
             J_EPS);
-        return F_rep; // Parameter values are not chosen wisely --> unrealistic overlaping ...
-                      // ignore.
+        return F_rep;
     }
-    // calculate the parameter (whatever dist is)
-    tmp = (vp1 - vp2).ScalarProduct(ep12); // < v_ij , e_ij >
+    tmp = (vp1 - vp2).ScalarProduct(ep12);
     v_ij = 0.5 * (tmp + fabs(tmp));
-    tmp2 = vp1.ScalarProduct(ep12); // < v_i , e_ij >
+    tmp2 = vp1.ScalarProduct(ep12);
 
-    // todo: runtime normsquare?
-    if(vp1.Norm() < J_EPS) { // if(norm(v_i)==0)
+    if(vp1.Norm() < J_EPS) {
         K_ij = 0;
     } else {
         double bla = tmp2 + fabs(tmp2);
-        K_ij = 0.25 * bla * bla / vp1.ScalarProduct(vp1); // squared
+        K_ij = 0.25 * bla * bla / vp1.ScalarProduct(vp1);
 
         if(K_ij < J_EPS * J_EPS) {
             F_rep = Point(0.0, 0.0);
@@ -251,30 +220,27 @@ Point GeneralizedCentrifugalForceModel::ForceRepPed(
         }
     }
 
-    const auto v0_1 = model1.v0;
-    nom = strengthNeighborRepulsion * v0_1 + v_ij; // Nu: 0=CFM, 0.28=modifCFM;
+    const auto v0_1 = s1.v0;
+    nom = strengthNeighborRepulsion * v0_1 + v_ij;
     nom *= nom;
 
     K_ij = sqrt(K_ij);
-    if(dist_eff <= smax) { // 5
+    if(dist_eff <= smax) {
         f = -agent1_mass * K_ij * nom / dist_intpol_left;
         F_rep = ep12 * maxNeighborRepulsionForce * f;
         return F_rep;
     }
 
-    //          smax    dist_intpol_left           dist_intpol_right       dist_eff_max
-    //           ----|-------------|--------------------------|--------------|----
-    //           5   |     4       |            3             |      2       | 1
-    if(dist_eff >= dist_intpol_right) { // 2
-        f = -agent1_mass * K_ij * nom / dist_intpol_right; // abs(NR-Dv(i)+Sa)
+    if(dist_eff >= dist_intpol_right) {
+        f = -agent1_mass * K_ij * nom / dist_intpol_right;
         f1 = -f / dist_intpol_right;
         px = hermite_interp(
             dist_eff, dist_intpol_right, maxNeighborInteractionDistance, f, 0, f1, 0);
         F_rep = ep12 * px;
-    } else if(dist_eff >= dist_intpol_left) { // 3
-        f = -agent1_mass * K_ij * nom / fabs(dist_eff); // abs(NR-Dv(i)+Sa)
+    } else if(dist_eff >= dist_intpol_left) {
+        f = -agent1_mass * K_ij * nom / fabs(dist_eff);
         F_rep = ep12 * f;
-    } else { // 4
+    } else {
         f = -agent1_mass * K_ij * nom / dist_intpol_left;
         f1 = -f / dist_intpol_left;
         px = hermite_interp(
@@ -283,9 +249,9 @@ Point GeneralizedCentrifugalForceModel::ForceRepPed(
     }
     if(F_rep.x != F_rep.x || F_rep.y != F_rep.y) {
         LOG_ERROR(
-            "NAN return p1{} p2 {} Frepx={:f} Frepy={:f} K_ij={:f}",
-            ped1.id,
-            ped2.id,
+            "NAN return p1={} p2={} Frepx={:f} Frepy={:f} K_ij={:f}",
+            s1.position,
+            s2.position,
             F_rep.x,
             F_rep.y,
             K_ij);
@@ -293,104 +259,74 @@ Point GeneralizedCentrifugalForceModel::ForceRepPed(
     return F_rep;
 }
 
-/* abstoßende Kraft zwischen ped und subroom
- * Parameter:
- *   - ped: Fußgänger für den die Kraft berechnet wird
- *   - subroom: SubRoom für den alle abstoßende Kräfte von Wänden berechnet werden
- * Rückgabewerte:
- *   - Vektor(x,y) mit Summe aller abstoßenden Kräfte im SubRoom
- * */
-
 inline Point GeneralizedCentrifugalForceModel::ForceRepRoom(
-    const GenericAgent& ped,
+    const State& state,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& walls = envQuery.LineSegmentsInRange(std::get<State>(ped.model).position);
-
-    auto f = std::accumulate(
+    const auto& walls = envQuery.LineSegmentsInRange(state.position);
+    return std::accumulate(
         std::begin(walls),
         std::end(walls),
         Point(0, 0),
-        [this, &ped](const auto& acc, const auto& element) {
-            return acc + ForceRepWall(ped, element);
+        [this, &state](const auto& acc, const auto& element) {
+            return acc + ForceRepWall(state, element);
         });
-    return f;
 }
 
 inline Point
-GeneralizedCentrifugalForceModel::ForceRepWall(const GenericAgent& ped, const LineSegment& w) const
+GeneralizedCentrifugalForceModel::ForceRepWall(const State& state, const LineSegment& w) const
 {
     Point F = Point(0.0, 0.0);
-    const auto& model = std::get<State>(ped.model);
-    Point pt = w.ShortestPoint(model.position);
+    Point pt = w.ShortestPoint(state.position);
     double wlen = w.LengthSquare();
 
-    if(wlen < 0.01) { // ignore walls smaller than 10 cm
+    if(wlen < 0.01) {
         return F;
     }
-    // Kraft soll nur orthgonal wirken
-    // ???
-    if(fabs((w.p1 - w.p2).ScalarProduct(model.position - pt)) > J_EPS) {
+    if(fabs((w.p1 - w.p2).ScalarProduct(state.position - pt)) > J_EPS) {
         return F;
     }
-    double mind = 0.5; // for performance reasons this distance is assumed to be constant
-    double vn = w.NormalComp(
-        model.orientation * model.speed); // normal component of the velocity on the wall
-    F = ForceRepStatPoint(ped, pt, mind, vn);
+    double mind = 0.5;
+    double vn = w.NormalComp(state.orientation * state.speed);
+    F = ForceRepStatPoint(state, pt, mind, vn);
 
-    return F; // line --> l != 0
+    return F;
 }
 
-/* abstoßende Punktkraft zwischen ped und Punkt p
- * Parameter:
- *   - ped: Fußgänger für den die Kraft berechnet wird
- *   - p: Punkt von dem die Kaft wirkt
- *   - l: Parameter zur Käfteinterpolation
- *   - vn: Parameter zur Käfteinterpolation
- * Rückgabewerte:
- *   - Vektor(x,y) mit abstoßender Kraft
- * */
-// TODO: use effective DistanceToEllipse and simplify this function.
 Point GeneralizedCentrifugalForceModel::ForceRepStatPoint(
-    const GenericAgent& ped,
+    const State& state,
     const Point& p,
     double l,
     double vn) const
 {
     Point F_rep = Point(0.0, 0.0);
-    // TODO(kkratz): this will fail for speed 0.
-    // I think the code can be rewritten to account for orientation and speed separately
-    const auto& model = std::get<State>(ped.model);
-    const Point v = model.orientation * model.speed;
-    Point dist = p - model.position; // x- and y-coordinate of the distance between ped and p
-    double d = dist.Norm(); // distance between the centre of ped and point p
-    Point e_ij; // x- and y-coordinate of the normalized vector between ped and p
+    const Point v = state.orientation * state.speed;
+    Point dist = p - state.position;
+    double d = dist.Norm();
+    Point e_ij;
 
     double tmp;
     double bla;
     Point r;
-    Point pinE; // vorher x1, y1
-    const Ellipse E{model.Av, model.AMin, model.BMax, model.BMin};
+    Point pinE;
+    const Ellipse E{state.Av, state.AMin, state.BMax, state.BMin};
 
     if(d < J_EPS)
         return Point(0.0, 0.0);
     e_ij = dist / d;
-    tmp = v.ScalarProduct(e_ij); // < v_i , e_ij >;
+    tmp = v.ScalarProduct(e_ij);
     bla = (tmp + fabs(tmp));
-    if(!bla) // Fussgaenger nicht im Sichtfeld
+    if(!bla)
         return Point(0.0, 0.0);
-    if(fabs(v.x) < J_EPS && fabs(v.y) < J_EPS) // v==0)
+    if(fabs(v.x) < J_EPS && fabs(v.y) < J_EPS)
         return Point(0.0, 0.0);
     double K_ij;
-    K_ij = 0.5 * bla / v.Norm(); // K_ij
-    // Punkt auf der Ellipse
+    K_ij = 0.5 * bla / v.Norm();
     pinE =
-        p.TransformToEllipseCoordinates(model.position, model.orientation.x, model.orientation.y);
-    const auto v0 = model.v0;
-    // Punkt auf der Ellipse
-    r = E.PointOnEllipse(pinE, model.speed / v0, model.position, model.speed, model.orientation);
-    // interpolierte Kraft
-    F_rep = ForceInterpolation(v0, K_ij, e_ij, vn, d, (r - model.position).Norm(), l);
+        p.TransformToEllipseCoordinates(state.position, state.orientation.x, state.orientation.y);
+    const auto v0 = state.v0;
+    r = E.PointOnEllipse(pinE, state.speed / v0, state.position, state.speed, state.orientation);
+    F_rep = ForceInterpolation(v0, K_ij, e_ij, vn, d, (r - state.position).Norm(), l);
     return F_rep;
 }
 
@@ -406,43 +342,38 @@ Point GeneralizedCentrifugalForceModel::ForceInterpolation(
     Point F_rep;
     double nominator = strengthGeometryRepulsion * v0 + vn;
     nominator *= nominator * K_ij;
-    double f = 0, f1 = 0; // function value and its derivative at the interpolation point
-    double smax = l - maxGeometryInterpolationDistance; // max overlapping radius
-    double dist_intpol_left = l + maxGeometryInterpolationDistance; // r_eps
+    double f = 0, f1 = 0;
+    double smax = l - maxGeometryInterpolationDistance;
+    double dist_intpol_left = l + maxGeometryInterpolationDistance;
     double dist_intpol_right = maxGeometryInteractionDistance - maxGeometryInterpolationDistance;
 
     double dist_eff = d - r;
 
-    //         smax    dist_intpol_left      dist_intpol_right       dist_eff_max
-    //           ----|-------------|--------------------------|--------------|----
-    //       5   |     4       |            3             |      2       | 1
-
-    double px = 0; // value of the interpolated function
+    double px = 0;
     double tmp1 = maxGeometryInteractionDistance;
     double tmp2 = dist_intpol_right;
     double tmp3 = dist_intpol_left;
     double tmp5 = smax + r;
 
-    if(dist_eff >= tmp1) { // 1
-        // F_rep = Point(0.0, 0.0);
+    if(dist_eff >= tmp1) {
         return F_rep;
     }
 
-    if(dist_eff <= tmp5) { // 5
+    if(dist_eff <= tmp5) {
         F_rep = e * (-maxGeometryRepulsionForce);
         return F_rep;
     }
 
-    if(dist_eff > tmp2) { // 2
+    if(dist_eff > tmp2) {
         f = -nominator / dist_intpol_right;
-        f1 = -f / dist_intpol_right; // nominator / (dist_intpol_right^2) = derivativ of f
+        f1 = -f / dist_intpol_right;
         px = hermite_interp(
             dist_eff, dist_intpol_right, maxGeometryInteractionDistance, f, 0, f1, 0);
         F_rep = e * px;
-    } else if(dist_eff >= tmp3) { // 3
-        f = -nominator / fabs(dist_eff); // devided by abs f the effective distance
+    } else if(dist_eff >= tmp3) {
+        f = -nominator / fabs(dist_eff);
         F_rep = e * f;
-    } else { // 4 d > smax FIXME
+    } else {
         f = -nominator / dist_intpol_left;
         f1 = -f / dist_intpol_left;
         px = hermite_interp(
@@ -451,28 +382,24 @@ Point GeneralizedCentrifugalForceModel::ForceInterpolation(
     }
     return F_rep;
 }
-double GeneralizedCentrifugalForceModel::AgentToAgentSpacing(
-    const GenericAgent& agent1,
-    const GenericAgent& agent2) const
+
+double GeneralizedCentrifugalForceModel::AgentToAgentSpacing(const State& s1, const State& s2) const
 {
-    const auto& model1 = std::get<State>(agent1.model);
-    const auto& model2 = std::get<State>(agent2.model);
-    const Ellipse E1{model1.Av, model1.AMin, model1.BMax, model1.BMin};
-    const Ellipse E2{model2.Av, model2.AMin, model2.BMax, model2.BMin};
-    const auto v0_1 = model1.v0;
-    const auto v0_2 = model2.v0;
-    // Avoid division by zero by setting scale to 1 when v0 is 0
-    const double scale1 = (v0_1 == 0.0) ? 1.0 : model1.speed / v0_1;
-    const double scale2 = (v0_2 == 0.0) ? 1.0 : model2.speed / v0_2;
+    const Ellipse E1{s1.Av, s1.AMin, s1.BMax, s1.BMin};
+    const Ellipse E2{s2.Av, s2.AMin, s2.BMax, s2.BMin};
+    const auto v0_1 = s1.v0;
+    const auto v0_2 = s2.v0;
+    const double scale1 = (v0_1 == 0.0) ? 1.0 : s1.speed / v0_1;
+    const double scale2 = (v0_2 == 0.0) ? 1.0 : s2.speed / v0_2;
 
     return E1.EffectiveDistanceToEllipse(
         E2,
-        model1.position,
-        model2.position,
+        s1.position,
+        s2.position,
         scale1,
         scale2,
-        model1.speed,
-        model2.speed,
-        model1.orientation,
-        model2.orientation);
+        s1.speed,
+        s2.speed,
+        s1.orientation,
+        s2.orientation);
 }

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -47,7 +47,7 @@ void GeneralizedCentrifugalForceModel::ComputeNextState(
     const EnvironmentQuery& envQuery) const
 {
     const auto& state = std::get<State>(current);
-    const auto neighborStates = envQuery.OtherAgentsInRange(
+    const auto neighborStates = envQuery.OtherAgentStatesInRange(
         current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
@@ -118,7 +118,7 @@ void GeneralizedCentrifugalForceModel::CheckModelConstraint(
     constexpr double BMaxMax = 2.;
     validateConstraint(BMax, BMaxMin, BMaxMax, "BMax");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
+    const auto neighbors = envQuery.OtherAgentStatesInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighborState = std::get<State>(neighbor);
         const auto contanctDist = AgentToAgentSpacing(state, neighborState);

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.hpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.hpp
@@ -1,35 +1,23 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
-#include "LineSegment.hpp"
 
-class EnvironmentQuery;
+#include "GeneralizedCentrifugalForceModelState.hpp"
+#include "LineSegment.hpp"
 #include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
+
+class EnvironmentQuery;
 
 #include <fmt/core.h>
 
 class GeneralizedCentrifugalForceModel : public OperationalModel
 {
 public:
-    /// Per-agent state of the generalized centrifugal force model.
-    struct State {
-        Point position{};
-        Point orientation{1.0, 0.0};
-        double speed{};
-        Point e0{};
-        int orientationDelay{};
-        double mass{1.0};
-        double tau{0.5};
-        double v0{1.2};
-        double Av{1.0};
-        double AMin{0.2};
-        double BMin{0.2};
-        double BMax{0.4};
-    };
+    using State = GeneralizedCentrifugalForceModelState;
 
 private:
-    double _cutOffRadius{4.0}; // TODO (MC) check this free parameter
+    double _cutOffRadius{4.0};
     double strengthNeighborRepulsion{0.3};
     double strengthGeometryRepulsion{0.2};
     double maxNeighborInteractionDistance{2};
@@ -54,50 +42,25 @@ public:
     OperationalModelType Type() const override;
     void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& destination,
         const EnvironmentQuery& envQuery) const override;
-    void CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery)
+    void CheckModelConstraint(const OperationalModelState& state, const EnvironmentQuery& envQuery)
         const override;
 
 private:
-    /**
-     * Driving force \f$ F_i =\frac{\mathbf{v_0}-\mathbf{v_i}}{\tau}\f$
-     *
-     * @param ped Pointer to Pedestrians
-     * @param room Pointer to Room
-     *
-     * @return Point
-     */
     Point ForceDriv(
-        const GenericAgent& ped,
+        const State& state,
         Point target,
         double mass,
         double tau,
         double deltaT,
         Point& e0update) const;
-    /**
-     * Repulsive force between two pedestrians ped1 and ped2 according to
-     * the Generalized Centrifugal Force Model (chraibi2010a)
-     *
-     * @param ped1 Pointer to Pedestrian: First pedestrian
-     * @param ped2 Pointer to Pedestrian: Second pedestrian
-     *
-     * @return Point
-     */
-    Point ForceRepPed(const GenericAgent& ped1, const GenericAgent& ped2) const;
-    /**
-     * Repulsive force acting on pedestrian <ped> from the walls in
-     * <subroom>. The sum of all repulsive forces of the walls in <subroom> is calculated
-     * @see ForceRepWall
-     * @param ped Pointer to Pedestrian
-     * @param subroom Pointer to SubRoom
-     *
-     * @return
-     */
-    Point ForceRepRoom(const GenericAgent& ped, const EnvironmentQuery& envQuery) const;
-    Point ForceRepWall(const GenericAgent& ped, const LineSegment& l) const;
-    Point ForceRepStatPoint(const GenericAgent& ped, const Point& p, double l, double vn) const;
+    Point ForceRepPed(const State& s1, const State& s2) const;
+    Point ForceRepRoom(const State& state, const EnvironmentQuery& envQuery) const;
+    Point ForceRepWall(const State& state, const LineSegment& l) const;
+    Point ForceRepStatPoint(const State& state, const Point& p, double l, double vn) const;
     Point ForceInterpolation(
         double v0,
         double K_ij,
@@ -106,17 +69,5 @@ private:
         double d,
         double r,
         double l) const;
-    double AgentToAgentSpacing(const GenericAgent& agent, const GenericAgent& otherAgent) const;
-};
-
-template <>
-struct fmt::formatter<GeneralizedCentrifugalForceModel::State> {
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const GeneralizedCentrifugalForceModel::State& m, FormatContext& ctx) const
-    {
-        return fmt::format_to(ctx.out(), "GCFM[orientation={}, speed={}])", m.orientation, m.speed);
-    }
+    double AgentToAgentSpacing(const State& s1, const State& s2) const;
 };

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelState.hpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelState.hpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "Point.hpp"
+
+#include <fmt/core.h>
+
+struct GeneralizedCentrifugalForceModelState {
+    Point position{};
+    Point orientation{1.0, 0.0};
+    double speed{};
+    Point e0{};
+    int orientationDelay{};
+    double mass{1.0};
+    double tau{0.5};
+    double v0{1.2};
+    double Av{1.0};
+    double AMin{0.2};
+    double BMin{0.2};
+    double BMax{0.4};
+};
+
+template <>
+struct fmt::formatter<GeneralizedCentrifugalForceModelState> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const GeneralizedCentrifugalForceModelState& m, FormatContext& ctx) const
+    {
+        return fmt::format_to(ctx.out(), "GCFM[orientation={}, speed={}])", m.orientation, m.speed);
+    }
+};

--- a/libsimulator/src/OperationalModels/OperationalModel.hpp
+++ b/libsimulator/src/OperationalModels/OperationalModel.hpp
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
+#include "OperationalModelState.hpp"
 #include "OperationalModelType.hpp"
-
-class EnvironmentQuery;
+#include "Point.hpp"
 #include "SimulationError.hpp"
 
 #include <fmt/core.h>
 
 #include <string>
 
-struct GenericAgent;
+class EnvironmentQuery;
 
 template <typename T>
 void validateConstraint(
@@ -57,13 +57,16 @@ public:
     /// Computes the agent state for the next iteration.
     /// "next" arrives as an exact copy of "current"; implementations overwrite only the fields
     /// they change. Other agents must be read exclusively from the frozen current generation,
-    /// i.e. via "current" and the neighborhood search, never via "next".
+    /// i.e. via the environment query, never via "next". "destination" is the agent's current
+    /// routing waypoint.
     virtual void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& destination,
         const EnvironmentQuery& envQuery) const = 0;
 
-    virtual void
-    CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery) const = 0;
+    virtual void CheckModelConstraint(
+        const OperationalModelState& state,
+        const EnvironmentQuery& envQuery) const = 0;
 };

--- a/libsimulator/src/OperationalModels/OperationalModelState.hpp
+++ b/libsimulator/src/OperationalModels/OperationalModelState.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "AnticipationVelocityModel/AnticipationVelocityModelState.hpp"
+#include "CollisionFreeSpeedModel/CollisionFreeSpeedModelState.hpp"
+#include "CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2State.hpp"
+#include "CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3State.hpp"
+#include "CustomModel/CustomModelState.hpp"
+#include "GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModelState.hpp"
+#include "SocialForceModel/SocialForceModelState.hpp"
+#include "WarpDriver/WarpDriverModelState.hpp"
+
+#include <variant>
+
+using OperationalModelState = std::variant<
+    GeneralizedCentrifugalForceModelState,
+    CollisionFreeSpeedModelState,
+    CollisionFreeSpeedModelV2State,
+    CollisionFreeSpeedModelV3State,
+    AnticipationVelocityModelState,
+    SocialForceModelState,
+    WarpDriverModelState,
+    CustomModelState>;
+
+inline const Point& Position(const OperationalModelState& state)
+{
+    return std::visit([](const auto& s) -> const Point& { return s.position; }, state);
+}
+
+inline Point& Position(OperationalModelState& state)
+{
+    return std::visit([](auto& s) -> Point& { return s.position; }, state);
+}

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
@@ -2,15 +2,12 @@
 #include "SocialForceModel.hpp"
 
 #include "EnvironmentQuery.hpp"
-#include "GenericAgent.hpp"
 #include "LineSegment.hpp"
-#include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 #include "SimulationError.hpp"
 
 #include <cmath>
-#include <iterator>
 #include <numeric>
 #include <string>
 
@@ -26,45 +23,45 @@ OperationalModelType SocialForceModel::Type() const
 
 void SocialForceModel::ComputeNextState(
     double dT,
-    const GenericAgent& current,
-    GenericAgent& next,
+    const OperationalModelState& current,
+    OperationalModelState& next,
+    const Point& destination,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& model = std::get<State>(current.model);
-    auto forces = DrivingForce(current);
+    const auto& state = std::get<State>(current);
+    auto forces = DrivingForce(state, destination);
 
-    auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
+    const auto neighborStates = envQuery.OtherAgentsInRange(
+        current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
-    Point F_rep;
-    for(const auto& neighbor : neighborhood) {
-        F_rep += AgentForce(current, neighbor);
-    }
-    forces += F_rep / model.mass;
-    const auto& walls = envQuery.LineSegmentsInRange(model.position);
 
+    Point F_rep;
+    for(const auto& neighbor : neighborStates) {
+        F_rep += AgentForce(state, std::get<State>(neighbor));
+    }
+    forces += F_rep / state.mass;
+
+    const auto& walls = envQuery.LineSegmentsInRange(state.position);
     const auto obstacle_f = std::accumulate(
         std::begin(walls),
         std::end(walls),
         Point(0, 0),
-        [this, &current](const auto& acc, const auto& element) {
-            return acc + ObstacleForce(current, element);
+        [this, &state](const auto& acc, const auto& element) {
+            return acc + ObstacleForce(state, element);
         });
-    forces += obstacle_f / model.mass;
+    forces += obstacle_f / state.mass;
 
-    const auto velocity = model.velocity + forces * dT;
-    auto& nextModel = std::get<State>(next.model);
-    nextModel.position = model.position + velocity * dT;
-    nextModel.velocity = velocity;
+    const auto velocity = state.velocity + forces * dT;
+    auto& nextState = std::get<State>(next);
+    nextState.position = state.position + velocity * dT;
+    nextState.velocity = velocity;
 }
 
 void SocialForceModel::CheckModelConstraint(
-    const GenericAgent& agent,
+    const OperationalModelState& generic_state,
     const EnvironmentQuery& envQuery) const
 {
-    // none of these constraint are given by the paper but are useful to create a simulation that
-    // does not break immediately
     auto throwIfNegative = [](double value, std::string name) {
         if(value < 0) {
             throw SimulationError(
@@ -76,86 +73,75 @@ void SocialForceModel::CheckModelConstraint(
         }
     };
 
-    const auto& model = std::get<State>(agent.model);
+    const auto& state = std::get<State>(generic_state);
 
-    const auto mass = model.mass;
-    throwIfNegative(mass, "mass");
+    throwIfNegative(state.mass, "mass");
+    throwIfNegative(state.desiredSpeed, "desired speed");
+    throwIfNegative(state.reactionTime, "reaction time");
+    throwIfNegative(state.radius, "radius");
 
-    const auto desiredSpeed = model.desiredSpeed;
-    throwIfNegative(desiredSpeed, "desired speed");
-
-    const auto reactionTime = model.reactionTime;
-    throwIfNegative(reactionTime, "reaction time");
-
-    const auto radius = model.radius;
-    throwIfNegative(radius, "radius");
-
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
-        const auto& neighborPosition = std::get<State>(neighbor.model).position;
-        const auto distance = (model.position - neighborPosition).Norm();
+        const auto& neighborState = std::get<State>(neighbor);
+        const auto distance = (state.position - neighborState.position).Norm();
 
-        if(model.radius >= distance) {
+        if(state.radius >= distance) {
             throw SimulationError(
                 "Model constraint violation: Agent {} too close to agent {}: distance {}, "
                 "radius {}",
-                model.position,
-                neighborPosition,
+                state.position,
+                neighborState.position,
                 distance,
-                model.radius);
+                state.radius);
         }
     }
-    const auto maxRadius = model.radius / 2;
-    const auto lineSegments = envQuery.LineSegmentsInRange(model.position, maxRadius);
+    const auto maxRadius = state.radius / 2;
+    const auto lineSegments = envQuery.LineSegmentsInRange(state.position, maxRadius);
     if(std::begin(lineSegments) != std::end(lineSegments)) {
         throw SimulationError(
             "Model constraint violation: Agent {} too close to geometry boundaries, distance <= "
             "{}/2",
-            model.position,
-            model.radius);
+            state.position,
+            state.radius);
     }
 }
 
-Point SocialForceModel::DrivingForce(const GenericAgent& agent)
+Point SocialForceModel::DrivingForce(const State& state, const Point& destination)
 {
-    const auto& model = std::get<State>(agent.model);
-    const Point e0 = (agent.nextTarget - model.position).Normalized();
-    return (e0 * model.desiredSpeed - model.velocity) / model.reactionTime;
-};
+    const Point e0 = (destination - state.position).Normalized();
+    return (e0 * state.desiredSpeed - state.velocity) / state.reactionTime;
+}
+
 double SocialForceModel::PushingForceLength(double A, double B, double r, double distance)
 {
     return A * exp((r - distance) / B);
 }
 
-Point SocialForceModel::AgentForce(const GenericAgent& ped1, const GenericAgent& ped2) const
+Point SocialForceModel::AgentForce(const State& s1, const State& s2) const
 {
-    const auto& model1 = std::get<State>(ped1.model);
-    const auto& model2 = std::get<State>(ped2.model);
-
-    const double total_radius = model1.radius + model2.radius;
+    const double total_radius = s1.radius + s2.radius;
 
     return ForceBetweenPoints(
-        model1.position,
-        model2.position,
-        model1.agentScale,
-        model1.forceDistance,
+        s1.position,
+        s2.position,
+        s1.agentScale,
+        s1.forceDistance,
         total_radius,
-        model2.velocity - model1.velocity,
+        s2.velocity - s1.velocity,
         this->bodyForce,
         this->friction);
-};
+}
 
-Point SocialForceModel::ObstacleForce(const GenericAgent& agent, const LineSegment& segment) const
+Point SocialForceModel::ObstacleForce(const State& state, const LineSegment& segment) const
 {
-    const auto& model = std::get<State>(agent.model);
-    const Point pt = segment.ShortestPoint(model.position);
+    const Point pt = segment.ShortestPoint(state.position);
     return ForceBetweenPoints(
-        model.position,
+        state.position,
         pt,
-        model.obstacleScale,
-        model.forceDistance,
-        model.radius,
-        model.velocity,
+        state.obstacleScale,
+        state.forceDistance,
+        state.radius,
+        state.velocity,
         this->bodyForce,
         this->friction);
 }
@@ -170,7 +156,6 @@ Point SocialForceModel::ForceBetweenPoints(
     const double bodyForce,
     const double friction)
 {
-    // todo reduce range of force to 180 degrees
     const double dist = (pt1 - pt2).Norm();
     double pushing_force_length = PushingForceLength(A, B, radius, dist);
     double friction_force_length = 0;

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
@@ -31,7 +31,7 @@ void SocialForceModel::ComputeNextState(
     const auto& state = std::get<State>(current);
     auto forces = DrivingForce(state, destination);
 
-    const auto neighborStates = envQuery.OtherAgentsInRange(
+    const auto neighborStates = envQuery.OtherAgentStatesInRange(
         current, _cutOffRadius, [&envQuery, from = state.position](const Point& to) {
             return envQuery.NoGeometryBetween(from, to);
         });
@@ -80,7 +80,7 @@ void SocialForceModel::CheckModelConstraint(
     throwIfNegative(state.reactionTime, "reaction time");
     throwIfNegative(state.radius, "radius");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(generic_state, 2.0);
+    const auto neighbors = envQuery.OtherAgentStatesInRange(generic_state, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighborState = std::get<State>(neighbor);
         const auto distance = (state.position - neighborState.position).Norm();

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.hpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.hpp
@@ -2,34 +2,24 @@
 #pragma once
 
 #include "LineSegment.hpp"
-
-class EnvironmentQuery;
 #include "OperationalModel.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
+#include "SocialForceModelState.hpp"
+
+class EnvironmentQuery;
 
 #include <fmt/core.h>
 
 class SocialForceModel : public OperationalModel
 {
 public:
-    /// Per-agent state of the social force model.
-    struct State {
-        Point position{};
-        Point velocity{}; // v
-        double mass{80.0}; // m
-        double desiredSpeed{0.8}; // v0
-        double reactionTime{0.5}; // tau
-        double agentScale{2000.0}; // A for other agents
-        double obstacleScale{2000.0}; // A for obstacles
-        double forceDistance{0.08}; // B
-        double radius{0.3}; // r
-    };
+    using State = SocialForceModelState;
 
 private:
     double _cutOffRadius{2.5};
-    double bodyForce{120000}; // k
-    double friction{240000}; // kappa
+    double bodyForce{120000};
+    double friction{240000};
 
 public:
     SocialForceModel(double bodyForce, double friction);
@@ -37,45 +27,17 @@ public:
     OperationalModelType Type() const override;
     void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& destination,
         const EnvironmentQuery& envQuery) const override;
-    void CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery)
+    void CheckModelConstraint(const OperationalModelState& state, const EnvironmentQuery& envQuery)
         const override;
 
 private:
-    /**
-     * Driving force acting on pedestrian <agent>
-     * @param agent reference to Pedestrian
-     *
-     * @return vector with driving force of pedestrian
-     */
-    static Point DrivingForce(const GenericAgent& agent);
-    /**
-     *  Repulsive force acting on pedestrian <ped1> from pedestrian <ped2>
-     * @param ped1 reference to Pedestrian 1 on whom the force acts on
-     * @param ped2 reference to Pedestrian 2, from whom the force originates
-     * @return vector with the repulsive force
-     */
-    Point AgentForce(const GenericAgent& ped1, const GenericAgent& ped2) const;
-    /**
-     *  Repulsive force acting on pedestrian <agent> from line segment <segment>
-     * @param agent reference to the Pedestrian on whom the force acts on
-     * @param segment reference to line segment, from which the force originates
-     * @return vector with the repulsive force
-     */
-    Point ObstacleForce(const GenericAgent& agent, const LineSegment& segment) const;
-    /**
-     * calculates the pushing and friction forces acting between <pt1> and <pt2>
-     * @param pt1 Point on which the forces act
-     * @param pt2 Point from which the forces originate
-     * @param A State scale
-     * @param B force distance
-     * @param r radius
-     * @param velocity velocity difference
-     * @param bodyForce body force parameter (k) of the agent the force acts on
-     * @param friction friction parameter (kappa) of the agent the force acts on
-     */
+    static Point DrivingForce(const State& state, const Point& destination);
+    Point AgentForce(const State& s1, const State& s2) const;
+    Point ObstacleForce(const State& state, const LineSegment& segment) const;
     static Point ForceBetweenPoints(
         const Point pt1,
         const Point pt2,
@@ -85,35 +47,5 @@ private:
         const Point velocity,
         const double bodyForce,
         const double friction);
-    /**
-     *  exponential function that specifies the length of the pushing force between two points
-     * @param A State scale
-     * @param B force distance
-     * @param r radius
-     * @param distance distance between the two points
-     * @return length of pushing force between the two points
-     */
     static double PushingForceLength(double A, double B, double r, double distance);
-};
-
-template <>
-struct fmt::formatter<SocialForceModel::State> {
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const SocialForceModel::State& m, FormatContext& ctx) const
-    {
-        return fmt::format_to(
-            ctx.out(),
-            "SFM[velocity={}, m={}, v0={}, tau={}, A_ped={}, A_obst={}, B={}, r={}])",
-            m.velocity,
-            m.mass,
-            m.desiredSpeed,
-            m.reactionTime,
-            m.agentScale,
-            m.obstacleScale,
-            m.forceDistance,
-            m.radius);
-    }
 };

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModelState.hpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModelState.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "Point.hpp"
+
+#include <fmt/core.h>
+
+struct SocialForceModelState {
+    Point position{};
+    Point velocity{};
+    double mass{80.0};
+    double desiredSpeed{0.8};
+    double reactionTime{0.5};
+    double agentScale{2000.0};
+    double obstacleScale{2000.0};
+    double forceDistance{0.08};
+    double radius{0.3};
+};
+
+template <>
+struct fmt::formatter<SocialForceModelState> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const SocialForceModelState& m, FormatContext& ctx) const
+    {
+        return fmt::format_to(
+            ctx.out(),
+            "SFM[velocity={}, m={}, v0={}, tau={}, A_ped={}, A_obst={}, B={}, r={}])",
+            m.velocity,
+            m.mass,
+            m.desiredSpeed,
+            m.reactionTime,
+            m.agentScale,
+            m.obstacleScale,
+            m.forceDistance,
+            m.radius);
+    }
+};

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
@@ -28,7 +28,6 @@
 #include "WarpDriverModel.hpp"
 
 #include "EnvironmentQuery.hpp"
-#include "GenericAgent.hpp"
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
 #include "SimulationError.hpp"
@@ -351,74 +350,65 @@ OperationalModelType WarpDriverModel::Type() const
 }
 
 void WarpDriverModel::CheckModelConstraint(
-    const GenericAgent& agent,
+    const OperationalModelState& generic_state,
     const EnvironmentQuery& /*envQuery*/) const
 {
-    const auto* data = std::get_if<State>(&agent.model);
+    const auto* data = std::get_if<State>(&generic_state);
     if(!data) {
         throw SimulationError(
-            "WarpDriverModel constraint check: agent {} does not have WarpDriverModel data",
-            agent.id);
+            "WarpDriverModel constraint check: agent does not have WarpDriverModel data");
     }
     if(data->radius <= 0.0) {
         throw SimulationError(
-            "WarpDriverModel constraint check: agent {} has invalid radius {}",
-            agent.id,
-            data->radius);
+            "WarpDriverModel constraint check: agent has invalid radius {}", data->radius);
     }
     if(data->v0 < 0.0) {
         throw SimulationError(
-            "WarpDriverModel constraint check: agent {} has invalid v0 {}", agent.id, data->v0);
+            "WarpDriverModel constraint check: agent has invalid v0 {}", data->v0);
     }
     if(this->_timeHorizon <= 0.0) {
         throw SimulationError(
-            "WarpDriverModel constraint check: agent {} has invalid timeHorizon {}, must be > 0",
-            agent.id,
+            "WarpDriverModel constraint check: agent has invalid timeHorizon {}, must be > 0",
             this->_timeHorizon);
     }
     if(this->_stepSize <= 0.0) {
         throw SimulationError(
-            "WarpDriverModel constraint check: agent {} has invalid stepSize {}, must be > 0",
-            agent.id,
+            "WarpDriverModel constraint check: agent has invalid stepSize {}, must be > 0",
             this->_stepSize);
     }
     if(this->_numSamples < 1) {
         throw SimulationError(
-            "WarpDriverModel constraint check: agent {} has invalid numSamples {}, must be >= 1",
-            agent.id,
+            "WarpDriverModel constraint check: agent has invalid numSamples {}, must be >= 1",
             this->_numSamples);
     }
     if(this->_timeUncertainty < 0.0) {
         throw SimulationError(
-            "WarpDriverModel constraint check: agent {} has invalid timeUncertainty {}, must be "
-            ">= 0",
-            agent.id,
+            "WarpDriverModel constraint check: agent has invalid timeUncertainty {}, must be >= 0",
             this->_timeUncertainty);
     }
     if(this->_velocityUncertaintyX < 0.0) {
         throw SimulationError(
-            "WarpDriverModel constraint check: agent {} has invalid velocityUncertaintyX {}, must "
+            "WarpDriverModel constraint check: agent has invalid velocityUncertaintyX {}, must "
             "be >= 0",
-            agent.id,
             this->_velocityUncertaintyX);
     }
     if(this->_velocityUncertaintyY < 0.0) {
         throw SimulationError(
-            "WarpDriverModel constraint check: agent {} has invalid velocityUncertaintyY {}, must "
+            "WarpDriverModel constraint check: agent has invalid velocityUncertaintyY {}, must "
             "be >= 0",
-            agent.id,
             this->_velocityUncertaintyY);
     }
 }
 
 void WarpDriverModel::ComputeNextState(
     double dT,
-    const GenericAgent& current,
-    GenericAgent& next,
+    const OperationalModelState& current,
+    OperationalModelState& next,
+    const Point& destination,
     const EnvironmentQuery& envQuery) const
 {
-    const auto& agentData = std::get<State>(current.model);
-    auto& nextData = std::get<State>(next.model);
+    const auto& agentData = std::get<State>(current);
+    auto& nextData = std::get<State>(next);
     const double speed = agentData.v0;
 
     // State orientation (unit vector). If zero, default to +x.
@@ -430,7 +420,7 @@ void WarpDriverModel::ComputeNextState(
     }
 
     // Direction towards destination
-    Point toTarget = current.nextTarget - agentData.position;
+    Point toTarget = destination - agentData.position;
     const double distToTarget = toTarget.Norm();
     if(distToTarget < 1e-9) {
         // The old update carried default-initialized stuck/detour state here,
@@ -454,7 +444,7 @@ void WarpDriverModel::ComputeNextState(
     const double dtSample = this->_timeHorizon / std::max(this->_numSamples - 1, 1);
 
     // === Step 2: Perceive - build collision probability field ===
-    const auto neighbors = envQuery.OtherAgentsInRange(current.model, _cutOffRadius);
+    const auto neighbors = envQuery.OtherAgentsInRange(current, _cutOffRadius);
 
     // Short-range repulsion: not part of the original Wolinski et al. (2016)
     // model, which is purely anticipatory. Added as a practical safety net
@@ -463,7 +453,7 @@ void WarpDriverModel::ComputeNextState(
     // Similar to the pushout mechanisms in CFS and AVM.
     Point repulsion{0.0, 0.0};
     for(const auto& neighbor : neighbors) {
-        const auto* nbData = std::get_if<State>(&neighbor.model);
+        const auto* nbData = std::get_if<State>(&neighbor);
         if(!nbData) {
             continue;
         }
@@ -500,7 +490,7 @@ void WarpDriverModel::ComputeNextState(
     }
 
     for(const auto& neighbor : neighbors) {
-        const auto* nbData = std::get_if<State>(&neighbor.model);
+        const auto* nbData = std::get_if<State>(&neighbor);
         if(!nbData) {
             continue;
         }

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.cpp
@@ -444,7 +444,7 @@ void WarpDriverModel::ComputeNextState(
     const double dtSample = this->_timeHorizon / std::max(this->_numSamples - 1, 1);
 
     // === Step 2: Perceive - build collision probability field ===
-    const auto neighbors = envQuery.OtherAgentsInRange(current, _cutOffRadius);
+    const auto neighbors = envQuery.OtherAgentStatesInRange(current, _cutOffRadius);
 
     // Short-range repulsion: not part of the original Wolinski et al. (2016)
     // model, which is purely anticipatory. Added as a practical safety net

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.hpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModel.hpp
@@ -2,12 +2,11 @@
 #pragma once
 
 #include "OperationalModel.hpp"
-
-class EnvironmentQuery;
 #include "OperationalModelType.hpp"
 #include "Point.hpp"
+#include "WarpDriverModelState.hpp"
 
-#include <fmt/core.h>
+class EnvironmentQuery;
 
 #include <cstdint>
 #include <random>
@@ -17,20 +16,8 @@ class EnvironmentQuery;
 class WarpDriverModel : public OperationalModel
 {
 public:
-    /// Per-agent state of the warp driver model.
-    struct State {
-        Point position{};
-        Point orientation{0.0, 0.0};
-        double radius{0.15};
-        double v0{1.2};
-        double stuckTime{0.0}; // elapsed time since anchor was set
-        double anchorX{0.0}; // position when stuck tracking began
-        double anchorY{0.0};
-        double detourTime{0.0}; // remaining time in detour mode
-        int detourSide{1}; // +1 = left, -1 = right of desired direction
-    };
+    using State = WarpDriverModelState;
 
-    /// 3-component space-time point/vector used internally
     struct SpaceTimePoint {
         double x{};
         double y{};
@@ -38,11 +25,9 @@ public:
     };
 
 private:
-    /// Precomputed 2D collision probability field I(x,y) and its gradient.
-    /// Constant along time axis; time is a validity window [0,1] normalized.
     struct IntrinsicField {
         std::vector<double> values;
-        std::vector<Point> gradients; // (dI/dx, dI/dy)
+        std::vector<Point> gradients;
         double xMin{-3.0};
         double xMax{3.0};
         double yMin{-3.0};
@@ -53,21 +38,16 @@ private:
         int ny{61};
 
         void Compute(double sigma);
-        /// Bilinear interpolation. Returns (0, {0,0}) for out-of-bounds.
         std::pair<double, Point> Sample(double x, double y) const;
     };
 
-    // Model-level parameters
     double _timeHorizon;
     double _stepSize;
     double _timeUncertainty;
     double _velocityUncertaintyX;
     double _velocityUncertaintyY;
     int _numSamples;
-
-    // Genuinely simulation-global state
     double _cutOffRadius;
-
     IntrinsicField _intrinsicField;
     mutable std::mt19937 _rng;
 
@@ -88,27 +68,11 @@ public:
 
     void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& destination,
         const EnvironmentQuery& envQuery) const override;
 
-    void CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery)
+    void CheckModelConstraint(const OperationalModelState& state, const EnvironmentQuery& envQuery)
         const override;
-};
-
-template <>
-struct fmt::formatter<WarpDriverModel::State> {
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const WarpDriverModel::State& m, FormatContext& ctx) const
-    {
-        return fmt::format_to(
-            ctx.out(),
-            "WarpDriver[orientation={}, radius={}, v0={}]",
-            m.orientation,
-            m.radius,
-            m.v0);
-    }
 };

--- a/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelState.hpp
+++ b/libsimulator/src/OperationalModels/WarpDriver/WarpDriverModelState.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include "Point.hpp"
+
+#include <fmt/core.h>
+
+struct WarpDriverModelState {
+    Point position{};
+    Point orientation{0.0, 0.0};
+    double radius{0.15};
+    double v0{1.2};
+    double stuckTime{0.0};
+    double anchorX{0.0};
+    double anchorY{0.0};
+    double detourTime{0.0};
+    int detourSide{1};
+};
+
+template <>
+struct fmt::formatter<WarpDriverModelState> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const WarpDriverModelState& m, FormatContext& ctx) const
+    {
+        return fmt::format_to(
+            ctx.out(),
+            "WarpDriver[orientation={}, radius={}, v0={}]",
+            m.orientation,
+            m.radius,
+            m.v0);
+    }
+};

--- a/libsimulator/src/Simulation.cpp
+++ b/libsimulator/src/Simulation.cpp
@@ -255,7 +255,7 @@ GenericAgent::ID Simulation::AddAgent(GenericAgent agent)
         throw SimulationError("Unknown stage id: {}", agent.stageId);
     }
 
-    if(const auto agentModelType = ModelTypeOf(agent.model);
+    if(const auto agentModelType = ModelTypeOf(agent.state);
        agentModelType != _operationalDecisionSystem.ModelType()) {
         throw SimulationError(
             "Agent model data of type '{}' does not match the simulation's operational model "

--- a/libsimulator/test/TestCustomModel.cpp
+++ b/libsimulator/test/TestCustomModel.cpp
@@ -37,13 +37,14 @@ class MinimalCustomModel : public CustomModel
 public:
     void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& /*destination*/,
         const EnvironmentQuery&) const override
     {
-        const auto& currentModelData = std::get<CustomModel::State>(current.model);
+        const auto& currentModelData = std::get<CustomModel::State>(current);
         const auto& state = currentModelData.Get<MinimalState>();
-        auto& nextModelData = std::get<CustomModel::State>(next.model);
+        auto& nextModelData = std::get<CustomModel::State>(next);
         auto& nextState = nextModelData.Get<MinimalState>();
 
         nextModelData.position = currentModelData.position + state.velocity * dT;
@@ -51,7 +52,9 @@ public:
         nextState.applications = state.applications + 1;
     }
 
-    void CheckModelConstraint(const GenericAgent&, const EnvironmentQuery&) const override {}
+    void CheckModelConstraint(const OperationalModelState&, const EnvironmentQuery&) const override
+    {
+    }
 };
 
 GenericAgent MakeAgent(GenericAgent::ModelState model)
@@ -121,7 +124,7 @@ TEST(CustomModel, RunsThroughOperationalDecisionSystem)
     system.Run(0.5, 0.0, neighborhoodSearch, geometry, agents);
 
     const auto& agent = agents.front();
-    const auto& state = std::get<CustomModel::State>(agent.model).Get<MinimalState>();
+    const auto& state = std::get<CustomModel::State>(agent.state).Get<MinimalState>();
     ASSERT_EQ(agent.position(), Point(1.0, 0.0));
     ASSERT_EQ(state.applications, 1);
 }
@@ -129,25 +132,25 @@ TEST(CustomModel, RunsThroughOperationalDecisionSystem)
 TEST(ModelTypeOf, MapsEveryAgentModelDataToItsOperationalModelType)
 {
     ASSERT_EQ(
-        ModelTypeOf(GenericAgent::ModelState{GeneralizedCentrifugalForceModel::State{}}),
+        ModelTypeOf(GenericAgent::ModelState{GeneralizedCentrifugalForceModelState{}}),
         OperationalModelType::GENERALIZED_CENTRIFUGAL_FORCE);
     ASSERT_EQ(
-        ModelTypeOf(GenericAgent::ModelState{CollisionFreeSpeedModel::State{}}),
+        ModelTypeOf(GenericAgent::ModelState{CollisionFreeSpeedModelState{}}),
         OperationalModelType::COLLISION_FREE_SPEED);
     ASSERT_EQ(
-        ModelTypeOf(GenericAgent::ModelState{CollisionFreeSpeedModelV2::State{}}),
+        ModelTypeOf(GenericAgent::ModelState{CollisionFreeSpeedModelV2State{}}),
         OperationalModelType::COLLISION_FREE_SPEED_V2);
     ASSERT_EQ(
-        ModelTypeOf(GenericAgent::ModelState{CollisionFreeSpeedModelV3::State{}}),
+        ModelTypeOf(GenericAgent::ModelState{CollisionFreeSpeedModelV3State{}}),
         OperationalModelType::COLLISION_FREE_SPEED_V3);
     ASSERT_EQ(
-        ModelTypeOf(GenericAgent::ModelState{AnticipationVelocityModel::State{}}),
+        ModelTypeOf(GenericAgent::ModelState{AnticipationVelocityModelState{}}),
         OperationalModelType::ANTICIPATION_VELOCITY_MODEL);
     ASSERT_EQ(
-        ModelTypeOf(GenericAgent::ModelState{SocialForceModel::State{}}),
+        ModelTypeOf(GenericAgent::ModelState{SocialForceModelState{}}),
         OperationalModelType::SOCIAL_FORCE);
     ASSERT_EQ(
-        ModelTypeOf(GenericAgent::ModelState{WarpDriverModel::State{}}),
+        ModelTypeOf(GenericAgent::ModelState{WarpDriverModelState{}}),
         OperationalModelType::WARP_DRIVER);
     ASSERT_EQ(
         ModelTypeOf(GenericAgent::ModelState{CustomModel::State{MinimalState{}}}),

--- a/libsimulator/test/TestEnvironmentQuery.cpp
+++ b/libsimulator/test/TestEnvironmentQuery.cpp
@@ -63,7 +63,7 @@ TEST(EnvironmentQuery, AgentsInRangeExcludesSelf)
     const auto geo = OpenGeometry();
     const auto q = env.query(geo);
 
-    const auto result = q.OtherAgentsInRange(env.agents[0].state, 100.0);
+    const auto result = q.OtherAgentStatesInRange(env.agents[0].state, 100.0);
     EXPECT_TRUE(result.empty());
 }
 
@@ -77,7 +77,7 @@ TEST(EnvironmentQuery, AgentsInRangeNoFilterReturnsAllInRadius)
     const auto geo = OpenGeometry();
     const auto q = env.query(geo);
 
-    const auto result = q.OtherAgentsInRange(env.agents[0].state, 5.0);
+    const auto result = q.OtherAgentStatesInRange(env.agents[0].state, 5.0);
     EXPECT_EQ(result.size(), 3u);
 }
 
@@ -91,7 +91,7 @@ TEST(EnvironmentQuery, AgentsInRangeCustomFilterRejectsAll)
     const auto q = env.query(geo);
 
     const auto result =
-        q.OtherAgentsInRange(env.agents[0].state, 5.0, [](const Point&) { return false; });
+        q.OtherAgentStatesInRange(env.agents[0].state, 5.0, [](const Point&) { return false; });
     EXPECT_TRUE(result.empty());
 }
 
@@ -105,8 +105,8 @@ TEST(EnvironmentQuery, AgentsInRangeCustomFilterSelectsSubset)
     const auto geo = OpenGeometry();
     const auto q = env.query(geo);
 
-    const auto result =
-        q.OtherAgentsInRange(env.agents[0].state, 5.0, [](const Point& to) { return to.x >= 0.0; });
+    const auto result = q.OtherAgentStatesInRange(
+        env.agents[0].state, 5.0, [](const Point& to) { return to.x >= 0.0; });
 
     ASSERT_EQ(result.size(), 2u);
     for(const auto& neighbor : result) {
@@ -124,7 +124,7 @@ TEST(EnvironmentQuery, NoGeometryBetweenFiltersOccludedAgents)
     const auto q = env.query(geo);
 
     const auto from = env.agents[0].position();
-    const auto result = q.OtherAgentsInRange(
+    const auto result = q.OtherAgentStatesInRange(
         env.agents[0].state, 5.0, [&](const Point& to) { return q.NoGeometryBetween(from, to); });
 
     ASSERT_EQ(result.size(), 1u);
@@ -141,7 +141,7 @@ TEST(EnvironmentQuery, AgentsInRangeCustomFilterReceivesNoSelf)
     const auto q = env.query(geo);
 
     const auto selfPos = env.agents[0].position();
-    q.OtherAgentsInRange(env.agents[0].state, 5.0, [&](const Point& to) {
+    q.OtherAgentStatesInRange(env.agents[0].state, 5.0, [&](const Point& to) {
         if(to == selfPos) {
             ADD_FAILURE() << "filter was called with the querying agent's own position";
         }
@@ -158,6 +158,6 @@ TEST(EnvironmentQuery, AgentsInRangeOutOfRadiusNotReturned)
     const auto q = env.query(geo);
 
     const auto result =
-        q.OtherAgentsInRange(env.agents[0].state, 1.0, [](const Point&) { return true; });
+        q.OtherAgentStatesInRange(env.agents[0].state, 1.0, [](const Point&) { return true; });
     EXPECT_TRUE(result.empty());
 }

--- a/libsimulator/test/TestEnvironmentQuery.cpp
+++ b/libsimulator/test/TestEnvironmentQuery.cpp
@@ -63,7 +63,7 @@ TEST(EnvironmentQuery, AgentsInRangeExcludesSelf)
     const auto geo = OpenGeometry();
     const auto q = env.query(geo);
 
-    const auto result = q.OtherAgentsInRange(env.agents[0], 100.0);
+    const auto result = q.OtherAgentsInRange(env.agents[0].state, 100.0);
     EXPECT_TRUE(result.empty());
 }
 
@@ -77,7 +77,7 @@ TEST(EnvironmentQuery, AgentsInRangeNoFilterReturnsAllInRadius)
     const auto geo = OpenGeometry();
     const auto q = env.query(geo);
 
-    const auto result = q.OtherAgentsInRange(env.agents[0], 5.0);
+    const auto result = q.OtherAgentsInRange(env.agents[0].state, 5.0);
     EXPECT_EQ(result.size(), 3u);
 }
 
@@ -91,7 +91,7 @@ TEST(EnvironmentQuery, AgentsInRangeCustomFilterRejectsAll)
     const auto q = env.query(geo);
 
     const auto result =
-        q.OtherAgentsInRange(env.agents[0], 5.0, [](const Point&) { return false; });
+        q.OtherAgentsInRange(env.agents[0].state, 5.0, [](const Point&) { return false; });
     EXPECT_TRUE(result.empty());
 }
 
@@ -106,11 +106,11 @@ TEST(EnvironmentQuery, AgentsInRangeCustomFilterSelectsSubset)
     const auto q = env.query(geo);
 
     const auto result =
-        q.OtherAgentsInRange(env.agents[0], 5.0, [](const Point& to) { return to.x >= 0.0; });
+        q.OtherAgentsInRange(env.agents[0].state, 5.0, [](const Point& to) { return to.x >= 0.0; });
 
     ASSERT_EQ(result.size(), 2u);
     for(const auto& neighbor : result) {
-        EXPECT_GE(std::get<State>(neighbor.model).position.x, 0.0);
+        EXPECT_GE(std::get<State>(neighbor).position.x, 0.0);
     }
 }
 
@@ -125,10 +125,10 @@ TEST(EnvironmentQuery, NoGeometryBetweenFiltersOccludedAgents)
 
     const auto from = env.agents[0].position();
     const auto result = q.OtherAgentsInRange(
-        env.agents[0], 5.0, [&](const Point& to) { return q.NoGeometryBetween(from, to); });
+        env.agents[0].state, 5.0, [&](const Point& to) { return q.NoGeometryBetween(from, to); });
 
     ASSERT_EQ(result.size(), 1u);
-    EXPECT_EQ(std::get<State>(result[0].model).position, Point(0, 1));
+    EXPECT_EQ(std::get<State>(result[0]).position, Point(0, 1));
 }
 
 TEST(EnvironmentQuery, AgentsInRangeCustomFilterReceivesNoSelf)
@@ -141,7 +141,7 @@ TEST(EnvironmentQuery, AgentsInRangeCustomFilterReceivesNoSelf)
     const auto q = env.query(geo);
 
     const auto selfPos = env.agents[0].position();
-    q.OtherAgentsInRange(env.agents[0], 5.0, [&](const Point& to) {
+    q.OtherAgentsInRange(env.agents[0].state, 5.0, [&](const Point& to) {
         if(to == selfPos) {
             ADD_FAILURE() << "filter was called with the querying agent's own position";
         }
@@ -157,6 +157,7 @@ TEST(EnvironmentQuery, AgentsInRangeOutOfRadiusNotReturned)
     const auto geo = OpenGeometry();
     const auto q = env.query(geo);
 
-    const auto result = q.OtherAgentsInRange(env.agents[0], 1.0, [](const Point&) { return true; });
+    const auto result =
+        q.OtherAgentsInRange(env.agents[0].state, 1.0, [](const Point&) { return true; });
     EXPECT_TRUE(result.empty());
 }

--- a/libsimulator/test/TestGenericAgentFormatter.cpp
+++ b/libsimulator/test/TestGenericAgentFormatter.cpp
@@ -15,30 +15,30 @@ static GenericAgent make_agent(GenericAgent::ModelState model)
 
 TEST(GenericAgentFormatter, FormatsGeneralizedCentrifugalForceModelAgent)
 {
-    auto agent = make_agent(GeneralizedCentrifugalForceModel::State{});
+    auto agent = make_agent(GeneralizedCentrifugalForceModelState{});
     ASSERT_NO_THROW((void) fmt::format("{}", agent));
 }
 
 TEST(GenericAgentFormatter, FormatsCollisionFreeSpeedModelAgent)
 {
-    auto agent = make_agent(CollisionFreeSpeedModel::State{});
+    auto agent = make_agent(CollisionFreeSpeedModelState{});
     ASSERT_NO_THROW((void) fmt::format("{}", agent));
 }
 
 TEST(GenericAgentFormatter, FormatsCollisionFreeSpeedModelV2Agent)
 {
-    auto agent = make_agent(CollisionFreeSpeedModelV2::State{});
+    auto agent = make_agent(CollisionFreeSpeedModelV2State{});
     ASSERT_NO_THROW((void) fmt::format("{}", agent));
 }
 
 TEST(GenericAgentFormatter, FormatsAnticipationVelocityModelAgent)
 {
-    auto agent = make_agent(AnticipationVelocityModel::State{});
+    auto agent = make_agent(AnticipationVelocityModelState{});
     ASSERT_NO_THROW((void) fmt::format("{}", agent));
 }
 
 TEST(GenericAgentFormatter, FormatsSocialForceModelAgent)
 {
-    auto agent = make_agent(SocialForceModel::State{});
+    auto agent = make_agent(SocialForceModelState{});
     ASSERT_NO_THROW((void) fmt::format("{}", agent));
 }

--- a/libsimulator/test/TestStage.cpp
+++ b/libsimulator/test/TestStage.cpp
@@ -33,7 +33,7 @@ TEST_F(StagesTests, NotifiableWaitingSetTargetIsCorrect)
             GenericAgent::ID::Invalid,
             Journey::ID::Invalid,
             waitingSet.Id(),
-            CollisionFreeSpeedModel::State{.position = waitingPoints[i]});
+            CollisionFreeSpeedModelState{.position = waitingPoints[i]});
         neighborhoodSearch.AddAgent(agent);
 
         const auto& target = waitingSet.Target(agent);
@@ -48,7 +48,7 @@ TEST_F(StagesTests, NotifiableWaitingSetTargetIsCorrect)
             GenericAgent::ID::Invalid,
             Journey::ID::Invalid,
             waitingSet.Id(),
-            CollisionFreeSpeedModel::State{});
+            CollisionFreeSpeedModelState{});
         neighborhoodSearch.AddAgent(agentToLastWaitingSetPos);
         const auto& target = waitingSet.Target(agentToLastWaitingSetPos);
         ASSERT_EQ(target, waitingPoints.back());

--- a/notebooks/motivation.ipynb
+++ b/notebooks/motivation.ipynb
@@ -298,7 +298,7 @@
     "for id in ids_third_group:\n",
     "    for agent in simulation.agents():\n",
     "        if agent.id == id:\n",
-    "            agent.model.desired_speed = v0_slow\n",
+    "            agent.state.desired_speed = v0_slow\n",
     "\n",
     "while simulation.agent_count() > 0:\n",
     "    simulation.iterate()\n",

--- a/python_bindings_jupedsim/agent.cpp
+++ b/python_bindings_jupedsim/agent.cpp
@@ -36,7 +36,7 @@ void init_agent(py::module_& m)
         .def_property_readonly(
             "next_target", [](const GenericAgent& agent) { return intoTuple(agent.nextTarget); })
         .def_property_readonly(
-            "model",
-            [](GenericAgent& agent) -> auto& { return agent.model; },
+            "state",
+            [](GenericAgent& agent) -> auto& { return agent.state; },
             py::return_value_policy::reference);
 }

--- a/python_bindings_jupedsim/environment_query.cpp
+++ b/python_bindings_jupedsim/environment_query.cpp
@@ -3,6 +3,8 @@
 #include "EnvironmentQuery.hpp"
 #include "GenericAgent.hpp"
 #include "LineSegment.hpp"
+#include "OperationalModels/CustomModel/CustomModel.hpp"
+#include "OperationalModels/OperationalModelState.hpp"
 #include "conversion.hpp"
 
 #include <pybind11/functional.h>
@@ -16,12 +18,12 @@ void init_environment_query(py::module_& m)
     py::class_<EnvironmentQuery>(m, "EnvironmentQuery")
         .def(
             "other_agents_in_range",
-            [](const EnvironmentQuery& self, const GenericAgent& agent, double radius) {
-                return self.OtherAgentsInRange(agent.model, radius);
+            [](const EnvironmentQuery& self, const CustomModel::State& state, double radius) {
+                return self.OtherAgentsInRange(OperationalModelState{state}, radius);
             },
-            py::arg("agent"),
+            py::arg("state"),
             py::arg("radius"),
-            "All agents within radius of agent (self excluded).")
+            "All agents within radius of state (self excluded).")
         .def(
             "no_wall_between",
             [](const EnvironmentQuery& self,

--- a/python_bindings_jupedsim/environment_query.cpp
+++ b/python_bindings_jupedsim/environment_query.cpp
@@ -17,9 +17,9 @@ void init_environment_query(py::module_& m)
 {
     py::class_<EnvironmentQuery>(m, "EnvironmentQuery")
         .def(
-            "other_agents_in_range",
+            "other_agent_states_in_range",
             [](const EnvironmentQuery& self, const CustomModel::State& state, double radius) {
-                return self.OtherAgentsInRange(OperationalModelState{state}, radius);
+                return self.OtherAgentStatesInRange(OperationalModelState{state}, radius);
             },
             py::arg("state"),
             py::arg("radius"),

--- a/python_bindings_jupedsim/python_model.cpp
+++ b/python_bindings_jupedsim/python_model.cpp
@@ -179,7 +179,7 @@ void init_python_model(py::module_& m)
             return data;
         }))
         .def_property_readonly(
-            "model", [](CustomModel::State& data) { return data.Get<GilSafePyObject>().Get(); })
+            "state", [](CustomModel::State& data) { return data.Get<GilSafePyObject>().Get(); })
         .def_property_readonly("position", [](const CustomModel::State& data) {
             return std::make_tuple(data.position.x, data.position.y);
         });

--- a/python_bindings_jupedsim/python_model.cpp
+++ b/python_bindings_jupedsim/python_model.cpp
@@ -5,6 +5,8 @@
 #include "GenericAgent.hpp"
 #include "OperationalModel.hpp"
 #include "OperationalModels/CustomModel/CustomModel.hpp"
+#include "OperationalModels/OperationalModelState.hpp"
+#include "Point.hpp"
 #include "SimulationError.hpp"
 #include "conversion.hpp"
 
@@ -86,21 +88,27 @@ PythonModel::PythonModel(py::object model) : _model(std::move(model))
 
 void PythonModel::ComputeNextState(
     double dT,
-    const GenericAgent& current,
-    GenericAgent& next,
+    const OperationalModelState& current,
+    OperationalModelState& next,
+    const Point& destination,
     const EnvironmentQuery& envQuery) const
 {
     py::gil_scoped_acquire gil;
 
-    py::object pythonAgent = py::cast(current);
+    const auto& currentState = std::get<CustomModel::State>(current);
+    auto& nextState = std::get<CustomModel::State>(next);
+
+    // Copy-construct the Python-facing state (shares GilSafePyObject by refcount, not clone).
+    py::object pythonState = py::cast(currentState);
+    py::object destTuple = py::make_tuple(destination.x, destination.y);
     py::object pythonEnvQuery = py::cast(&envQuery, py::return_value_policy::reference);
 
-    py::object pythonUpdate = _model.attr("_compute_next_state")(dT, pythonAgent, pythonEnvQuery);
+    py::object pythonUpdate =
+        _model.attr("_compute_next_state")(dT, pythonState, destTuple, pythonEnvQuery);
 
-    // "next" shares the Python state object with "current" (GilSafePyObject copies are
-    // refcounted, not cloned), so this also rejects returning the current state instance.
-    auto& nextModelData = std::get<CustomModel::State>(next.model);
-    auto& customModelData = nextModelData.Get<GilSafePyObject>();
+    // nextState shares Python payload with currentState initially; reject returning the same
+    // object.
+    auto& customModelData = nextState.Get<GilSafePyObject>();
     if(pythonUpdate.is(customModelData.Get())) {
         throw SimulationError(
             "Current and updated model state are the same instance. "
@@ -121,12 +129,8 @@ void PythonModel::ComputeNextState(
     }
 
     try {
-        // Sync the GIL-free position cache from the returned Python state so the
-        // framework can read the agent position without acquiring the GIL.
-        nextModelData.position = intoPoint(py::cast<std::tuple<double, double>>(attr));
+        nextState.position = intoPoint(py::cast<std::tuple<double, double>>(attr));
     } catch(const py::cast_error&) {
-        // Diagnostics run Python code on the offending object; they must not
-        // be able to replace the error they describe.
         std::string actualType = "<unknown>";
         std::string valueRepr = "<unprintable>";
         try {
@@ -137,7 +141,6 @@ void PythonModel::ComputeNextState(
             valueRepr = std::string(py::repr(attr));
         } catch(const py::error_already_set&) {
         }
-
         throw SimulationError(
             "State returned by compute_next_state() has attribute '{}' of wrong type: "
             "expected tuple[float, float], got {} ({})",
@@ -148,15 +151,17 @@ void PythonModel::ComputeNextState(
     customModelData.Set(pythonUpdate);
 }
 
-void PythonModel::CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery)
-    const
+void PythonModel::CheckModelConstraint(
+    const OperationalModelState& state,
+    const EnvironmentQuery& envQuery) const
 {
     py::gil_scoped_acquire gil;
 
-    py::object pythonAgent = py::cast(agent);
+    const auto& customState = std::get<CustomModel::State>(state);
+    py::object pythonState = py::cast(customState);
     py::object pythonEnvQuery = py::cast(&envQuery, py::return_value_policy::reference);
 
-    _model.attr("_check_model_constraint")(pythonAgent, pythonEnvQuery);
+    _model.attr("_check_model_constraint")(pythonState, pythonEnvQuery);
 }
 
 void init_python_model(py::module_& m)
@@ -174,7 +179,10 @@ void init_python_model(py::module_& m)
             return data;
         }))
         .def_property_readonly(
-            "model", [](CustomModel::State& data) { return data.Get<GilSafePyObject>().Get(); });
+            "model", [](CustomModel::State& data) { return data.Get<GilSafePyObject>().Get(); })
+        .def_property_readonly("position", [](const CustomModel::State& data) {
+            return std::make_tuple(data.position.x, data.position.y);
+        });
 
     py::class_<PythonModel, OperationalModel, py::smart_holder>(m, "_PythonModel")
         .def(py::init<py::object>(), py::arg("model"));

--- a/python_bindings_jupedsim/python_model.hpp
+++ b/python_bindings_jupedsim/python_model.hpp
@@ -3,6 +3,7 @@
 
 #include "EnvironmentQuery.hpp"
 #include "OperationalModels/CustomModel/CustomModel.hpp"
+#include "Point.hpp"
 
 #include <pybind11/pybind11.h>
 
@@ -46,11 +47,12 @@ public:
 
     void ComputeNextState(
         double dT,
-        const GenericAgent& current,
-        GenericAgent& next,
+        const OperationalModelState& current,
+        OperationalModelState& next,
+        const Point& destination,
         const EnvironmentQuery& envQuery) const override;
 
-    void CheckModelConstraint(const GenericAgent& agent, const EnvironmentQuery& envQuery)
+    void CheckModelConstraint(const OperationalModelState& state, const EnvironmentQuery& envQuery)
         const override;
 
 private:

--- a/python_modules/jupedsim/jupedsim/agent.py
+++ b/python_modules/jupedsim/jupedsim/agent.py
@@ -25,7 +25,7 @@ class _ModelStateHandle:
     def __init__(self, simulation: Simulation, agent_id: int) -> None:
         """Do not use.
 
-        Model state handles are obtained via :attr:`Agent.model`.
+        Model state handles are obtained via :attr:`Agent.state`.
         """
         object.__setattr__(self, "_ModelStateHandle__simulation", simulation)
         object.__setattr__(self, "_ModelStateHandle__id", agent_id)
@@ -33,7 +33,7 @@ class _ModelStateHandle:
     def __resolve(self):
         # Transient reference: only valid for the duration of one attribute
         # access, never stored.
-        return self.__simulation._obj.agent(self.__id).model
+        return self.__simulation._obj.agent(self.__id).state
 
     def __getattr__(self, name: str) -> Any:
         if name.startswith("_"):
@@ -89,7 +89,7 @@ class Agent:
     .. code:: python
 
         agent.final_target = (1.0, 2.0)
-        agent.model.desired_speed = 1.5
+        agent.state.desired_speed = 1.5
 
     .. note ::
 
@@ -173,17 +173,17 @@ class Agent:
         return self.__resolve().next_destination
 
     @property
-    def model(self) -> Any:
+    def state(self) -> Any:
         """Access model specific state of this agent.
 
         For built-in models this returns a state handle that resolves the
         agent on every attribute access, e.g.
-        ``agent.model.desired_speed = 1.5``. For custom Python models this
+        ``agent.state.desired_speed = 1.5``. For custom Python models this
         returns the user supplied state object.
         """
-        state = self.__resolve().model
+        state = self.__resolve().state
         if isinstance(state, py_jps._CustomModelState):
-            return state.model
+            return state.state
         return _ModelStateHandle(self.__simulation, self.__id)
 
     def __repr__(self) -> str:
@@ -238,16 +238,16 @@ class _TransientAgent:
         return self.__obj.next_target
 
     @property
-    def model(self) -> Any:
+    def state(self) -> Any:
         """Model specific state of this agent.
 
         For custom models this is the user supplied state object. Treat it as
         read-only: state may only be changed by returning a new state object
         from ``compute_next_state``.
         """
-        state = self.__obj.model
+        state = self.__obj.state
         if isinstance(state, py_jps._CustomModelState):
-            return state.model
+            return state.state
         return state
 
     @property

--- a/python_modules/jupedsim/jupedsim/environment_query.py
+++ b/python_modules/jupedsim/jupedsim/environment_query.py
@@ -19,7 +19,7 @@ class EnvironmentQuery:
     Example — visibility-filtered neighborhood::
 
         def compute_next_state(self, dt, ped, env_query):
-            neighbors = env_query.other_agents_in_range(
+            neighbors = env_query.other_agent_states_in_range(
                 ped, 5.0,
                 lambda n: env_query.no_wall_between(ped.position, n.position)
             )
@@ -28,7 +28,7 @@ class EnvironmentQuery:
     def __init__(self, obj: py_jps.EnvironmentQuery) -> None:
         self._obj = obj
 
-    def other_agents_in_range(
+    def other_agent_states_in_range(
         self,
         state,
         radius: float,
@@ -47,7 +47,7 @@ class EnvironmentQuery:
         Returns:
             List of ``_CustomModelState`` objects. Only valid during the current callback.
         """
-        neighbors = self._obj.other_agents_in_range(state, radius)
+        neighbors = self._obj.other_agent_states_in_range(state, radius)
         if predicate is None:
             return neighbors
         return [n for n in neighbors if predicate(n)]
@@ -69,7 +69,7 @@ class EnvironmentQuery:
 
         Example::
 
-            neighbors = env_query.other_agents_in_range(
+            neighbors = env_query.other_agent_states_in_range(
                 ped, 5.0,
                 lambda n: env_query.no_wall_between(ped.position, n.position)
             )

--- a/python_modules/jupedsim/jupedsim/environment_query.py
+++ b/python_modules/jupedsim/jupedsim/environment_query.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Callable
 import jupedsim.native as py_jps
 
 if TYPE_CHECKING:
-    from jupedsim.agent import _TransientAgent
     from jupedsim.linesegment import LineSegment
 
 
@@ -31,30 +30,24 @@ class EnvironmentQuery:
 
     def other_agents_in_range(
         self,
-        agent: _TransientAgent,
+        state,
         radius: float,
-        predicate: Callable[[_TransientAgent], bool] | None = None,
-    ) -> list[_TransientAgent]:
-        """Return agents within *radius* of *agent*, excluding *agent* itself.
+        predicate: Callable | None = None,
+    ) -> list:
+        """Return agents within *radius* of *state*, excluding the querying agent.
 
         Args:
-            agent: The querying agent (automatically excluded from results).
+            state: The querying agent's model state (``_CustomModelState``).
             radius: Search radius in metres.
-            predicate: Optional callable ``(neighbor) -> bool``. Only agents for
-                which the predicate returns ``True`` are included. Use
+            predicate: Optional callable ``(neighbor) -> bool``. Only neighbors
+                for which the predicate returns ``True`` are included. Use
                 :meth:`no_wall_between` to filter by line-of-sight, or compose
                 multiple predicates with ``lambda n: p1(n) and p2(n)``.
 
         Returns:
-            List of transient agent views. Only valid during the current callback.
+            List of ``_CustomModelState`` objects. Only valid during the current callback.
         """
-        from jupedsim.agent import _TransientAgent
-
-        raw_agent = agent._native if hasattr(agent, "_native") else agent
-        neighbors = [
-            _TransientAgent(a)
-            for a in self._obj.other_agents_in_range(raw_agent, radius)
-        ]
+        neighbors = self._obj.other_agents_in_range(state, radius)
         if predicate is None:
             return neighbors
         return [n for n in neighbors if predicate(n)]

--- a/python_modules/jupedsim/jupedsim/models/custom_model.py
+++ b/python_modules/jupedsim/jupedsim/models/custom_model.py
@@ -9,7 +9,6 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from jupedsim.agent import _TransientAgent
     from jupedsim.environment_query import EnvironmentQuery
 
 
@@ -76,32 +75,33 @@ class CustomOperationalModel(ABC):
     def compute_next_state(
         self,
         dt: float,
-        ped: _TransientAgent,
+        state: CustomModelAgentState,
+        destination: tuple[float, float],
         env_query: EnvironmentQuery,
     ) -> CustomModelAgentState:
-        """Compute one update for ``ped``.
+        """Compute one update for the agent with the given *state*.
 
         Args:
             dt: Simulation time step in seconds.
-            ped: The agent being updated. Only valid for the duration of this call.
-            env_query: Spatial query object for the current step. Use it to
-                find neighboring agents and query geometry. Only valid for the
-                duration of this call.
+            state: Current per-agent state. Only valid for the duration of this call.
+            destination: Current navigation waypoint as ``(x, y)`` in metres.
+            env_query: Spatial query object for the current step. Only valid for
+                the duration of this call.
 
         Returns:
-            New agent state. Must be a new object -- returning ``ped.model``
-            unchanged raises an error.
+            New agent state. Must be a new object -- returning *state* unchanged
+            raises an error. Use ``dataclasses.replace(state, ...)`` to derive it.
         """
 
     def check_model_constraint(
         self,
-        ped: _TransientAgent,
+        state: CustomModelAgentState,
         env_query: EnvironmentQuery,
     ) -> None:
-        """Raise an exception when ``ped`` violates this model's constraints.
+        """Raise an exception when *state* violates this model's constraints.
 
         Args:
-            ped: The agent to validate.
+            state: Per-agent state to validate.
             env_query: Spatial query object for the current step.
         """
         pass
@@ -109,24 +109,21 @@ class CustomOperationalModel(ABC):
     def _compute_next_state(
         self,
         dt,
-        ped,
+        state,
+        destination,
         env_query,
     ) -> CustomModelAgentState:
-        from jupedsim.agent import _TransientAgent
         from jupedsim.environment_query import EnvironmentQuery
 
         return self.compute_next_state(
-            dt, _TransientAgent(ped), EnvironmentQuery(env_query)
+            dt, state.model, destination, EnvironmentQuery(env_query)
         )
 
     def _check_model_constraint(
         self,
-        ped,
+        state,
         env_query,
     ) -> None:
-        from jupedsim.agent import _TransientAgent
         from jupedsim.environment_query import EnvironmentQuery
 
-        self.check_model_constraint(
-            _TransientAgent(ped), EnvironmentQuery(env_query)
-        )
+        self.check_model_constraint(state.model, EnvironmentQuery(env_query))

--- a/python_modules/jupedsim/jupedsim/models/custom_model.py
+++ b/python_modules/jupedsim/jupedsim/models/custom_model.py
@@ -116,7 +116,7 @@ class CustomOperationalModel(ABC):
         from jupedsim.environment_query import EnvironmentQuery
 
         return self.compute_next_state(
-            dt, state.model, destination, EnvironmentQuery(env_query)
+            dt, state, destination, EnvironmentQuery(env_query)
         )
 
     def _check_model_constraint(
@@ -126,4 +126,4 @@ class CustomOperationalModel(ABC):
     ) -> None:
         from jupedsim.environment_query import EnvironmentQuery
 
-        self.check_model_constraint(state.model, EnvironmentQuery(env_query))
+        self.check_model_constraint(state, EnvironmentQuery(env_query))

--- a/python_modules/jupedsim/tests/test_environment_query.py
+++ b/python_modules/jupedsim/tests/test_environment_query.py
@@ -46,7 +46,7 @@ def _walled_room():
 
 
 class _CapturingModel(CustomOperationalModel):
-    """Calls other_agents_in_range for one designated probe agent and records results."""
+    """Calls other_agent_states_in_range for one designated probe agent and records results."""
 
     def __init__(self, probe_position, *, radius=5.0, predicate=None):
         super().__init__()
@@ -61,7 +61,7 @@ class _CapturingModel(CustomOperationalModel):
         ppx, ppy = self._probe_pos
         return abs(px - ppx) < 1e-4 and abs(py - ppy) < 1e-4
 
-    def compute_next_state(self, dt, ped, env_query):
+    def compute_next_state(self, dt, ped, destination, env_query):
         if self._is_probe(ped):
             self.predicate_positions.clear()
 
@@ -69,11 +69,11 @@ class _CapturingModel(CustomOperationalModel):
                 self.predicate_positions.append(tuple(neighbor.position))
                 return self._predicate(neighbor) if self._predicate else True
 
-            neighbors = env_query.other_agents_in_range(
+            neighbors = env_query.other_agent_states_in_range(
                 ped, self._radius, _tracking
             )
             self.neighbor_positions = [tuple(n.position) for n in neighbors]
-        return replace(ped.model, position=ped.model.position)
+        return replace(ped.state, position=ped.position)
 
 
 # ---------------------------------------------------------------------------
@@ -112,7 +112,7 @@ def test_reject_all_predicate_returns_empty():
 
 def test_group_filter_returns_only_matching_group():
     def same_group(neighbor):
-        return neighbor.model.group == 1
+        return neighbor.state.group == 1
 
     model = _CapturingModel((2.0, 10.0), radius=5.0, predicate=same_group)
     sim, exit_id, journey_id = _make_sim(model)
@@ -162,12 +162,12 @@ def test_no_wall_between_filters_occluded_agents():
             super().__init__()
             self.neighbor_positions: list[tuple] = []
 
-        def compute_next_state(self, dt, ped, env_query):
+        def compute_next_state(self, dt, ped, destination, env_query):
             px, py = ped.position
             if abs(px - 5.0) < 1e-4 and abs(py - 10.0) < 1e-4:
                 self.neighbor_positions = [
                     tuple(n.position)
-                    for n in env_query.other_agents_in_range(
+                    for n in env_query.other_agent_states_in_range(
                         ped,
                         20.0,
                         lambda n: env_query.no_wall_between(
@@ -175,7 +175,7 @@ def test_no_wall_between_filters_occluded_agents():
                         ),
                     )
                 ]
-            return replace(ped.model, position=ped.model.position)
+            return replace(ped.state, position=ped.position)
 
     model = _VisModel()
     sim, exit_id, journey_id = _make_sim(model, geometry=_walled_room())
@@ -201,12 +201,12 @@ def test_no_wall_between_agent_above_wall_is_seen():
             super().__init__()
             self.neighbor_positions: list[tuple] = []
 
-        def compute_next_state(self, _dt, ped, env_query):
+        def compute_next_state(self, _dt, ped, destination, env_query):
             px, py = ped.position
             if abs(px - 5.0) < 1e-4 and abs(py - 18.0) < 1e-4:
                 self.neighbor_positions = [
                     tuple(n.position)
-                    for n in env_query.other_agents_in_range(
+                    for n in env_query.other_agent_states_in_range(
                         ped,
                         20.0,
                         lambda n: env_query.no_wall_between(
@@ -214,7 +214,7 @@ def test_no_wall_between_agent_above_wall_is_seen():
                         ),
                     )
                 ]
-            return replace(ped.model, position=ped.model.position)
+            return replace(ped.state, position=ped.position)
 
     model = _VisModel()
     sim, exit_id, journey_id = _make_sim(model, geometry=_walled_room())
@@ -236,23 +236,23 @@ def test_composed_no_wall_between_and_group_filter():
             super().__init__()
             self.neighbor_positions: list[tuple] = []
 
-        def compute_next_state(self, _dt, ped, env_query):
+        def compute_next_state(self, _dt, ped, destination, env_query):
             px, py = ped.position
             if abs(px - 5.0) < 1e-4 and abs(py - 10.0) < 1e-4:
                 self.neighbor_positions = [
                     tuple(n.position)
-                    for n in env_query.other_agents_in_range(
+                    for n in env_query.other_agent_states_in_range(
                         ped,
                         20.0,
                         lambda neighbor: (
                             env_query.no_wall_between(
                                 ped.position, neighbor.position
                             )
-                            and neighbor.model.group == 1
+                            and neighbor.state.group == 1
                         ),
                     )
                 ]
-            return replace(ped.model, position=ped.model.position)
+            return replace(ped.state, position=ped.position)
 
     model = _ComposedModel()
     sim, exit_id, journey_id = _make_sim(model, geometry=_walled_room())

--- a/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
+++ b/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, replace
 
 import numpy as np
 from jupedsim.geometry import LineSegment
-from jupedsim.models.custom_model import (
+from jupedsim.states.custom_model import (
     CustomModelAgentState,
     CustomOperationalModel,
 )
@@ -48,7 +48,7 @@ class PythonSocialForceModel(CustomOperationalModel):
     All force helpers are static: math utilities (_normalize, _distance,
     _desired_force) operate on plain values, while _social_force and
     _obstacle_force take Agent wrappers and read per-agent parameters via
-    ``agent.model``.
+    ``agent.state``.
     """
 
     def __init__(
@@ -106,7 +106,7 @@ class PythonSocialForceModel(CustomOperationalModel):
         dist = np.sqrt(dx**2 + dy**2)
 
         # Minimum distance (sum of radii)
-        min_dist = agent.model.radius + other.model.radius
+        min_dist = agent.state.radius + other.state.radius
 
         if dist < 1e-3:  # Avoid division by zero
             return (0.0, 0.0)
@@ -120,23 +120,23 @@ class PythonSocialForceModel(CustomOperationalModel):
         t_y = n_x
 
         # Relative velocity
-        dvx = agent.model.velocity[0] - other.model.velocity[0]
-        dvy = agent.model.velocity[1] - other.model.velocity[1]
+        dvx = agent.state.velocity[0] - other.state.velocity[0]
+        dvy = agent.state.velocity[1] - other.state.velocity[1]
         dv_t = dvx * t_x + dvy * t_y  # tangential component
 
         # Distance-dependent factor
-        exp_factor = np.exp(-(dist - min_dist) / agent.model.force_distance)
+        exp_factor = np.exp(-(dist - min_dist) / agent.state.force_distance)
 
         # Normal force (repulsive)
-        f_n = agent.model.agent_scale * exp_factor
+        f_n = agent.state.agent_scale * exp_factor
 
         # Body contact force
         if dist < min_dist:
-            f_body = agent.model.body_force * (min_dist - dist)
+            f_body = agent.state.body_force * (min_dist - dist)
             f_n = f_n + f_body
 
         # Friction (tangential)
-        f_t = agent.model.friction * exp_factor * dv_t if dist < min_dist else 0
+        f_t = agent.state.friction * exp_factor * dv_t if dist < min_dist else 0
 
         # Total force components
         fx = (f_n + f_t * t_x) * n_x - f_t * t_x
@@ -166,14 +166,14 @@ class PythonSocialForceModel(CustomOperationalModel):
         n_y = (agent.position[1] - closest_point[1]) / dist
 
         # Distance-dependent factor
-        exp_factor = np.exp(-dist / agent.model.force_distance)
+        exp_factor = np.exp(-dist / agent.state.force_distance)
 
         # Normal force (repulsive)
-        f_n = agent.model.obstacle_scale * exp_factor
+        f_n = agent.state.obstacle_scale * exp_factor
 
         # Body contact force
-        if dist < agent.model.radius:
-            f_body = agent.model.body_force * (agent.model.radius - dist)
+        if dist < agent.state.radius:
+            f_body = agent.state.body_force * (agent.state.radius - dist)
             f_n = f_n + f_body
 
         fx = f_n * n_x
@@ -203,7 +203,7 @@ class PythonSocialForceModel(CustomOperationalModel):
         # eq 1 in paper
         target_dir = self._normalize(target_diff)
 
-        state = agent.model
+        state = agent.state
 
         # Initialize acceleration from desired force
         acc_x, acc_y = self._desired_force(

--- a/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
+++ b/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, replace
 
 import numpy as np
 from jupedsim.geometry import LineSegment
-from jupedsim.states.custom_model import (
+from jupedsim.models.custom_model import (
     CustomModelAgentState,
     CustomOperationalModel,
 )

--- a/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
+++ b/python_modules/jupedsim_examples/jupedsim_examples/models/pysocial_force.py
@@ -181,13 +181,14 @@ class PythonSocialForceModel(CustomOperationalModel):
 
         return (fx, fy)
 
-    def compute_next_state(self, dt: float, agent, env_query):
+    def compute_next_state(self, dt: float, agent, destination, env_query):
         """
         Compute new position using Social Force Model.
 
         Args:
             dt: time step [s]
-            agent: Agent (current agent, exposing position, target and model)
+            agent: _CustomModelState (position + model payload)
+            destination: current navigation waypoint as (x, y)
             env_query: EnvironmentQuery for neighbor and geometry queries
 
         Returns:
@@ -197,8 +198,8 @@ class PythonSocialForceModel(CustomOperationalModel):
 
         # Get target direction (normalized)
         target_diff = (
-            agent.next_target[0] - agent.position[0],
-            agent.next_target[1] - agent.position[1],
+            destination[0] - agent.position[0],
+            destination[1] - agent.position[1],
         )
         # eq 1 in paper
         target_dir = self._normalize(target_diff)
@@ -214,7 +215,7 @@ class PythonSocialForceModel(CustomOperationalModel):
         )
 
         # Add social forces from neighboring agents
-        for neighbor in env_query.other_agents_in_range(agent, 2.0):
+        for neighbor in env_query.other_agent_states_in_range(agent, 2.0):
             fx, fy = self._social_force(agent, neighbor)
             acc_x += fx / state.mass
             acc_y += fy / state.mass

--- a/python_modules/jupedsim_examples/tests/test_python_social_force_model.py
+++ b/python_modules/jupedsim_examples/tests/test_python_social_force_model.py
@@ -191,7 +191,7 @@ def test_per_agent_state_survives_iterations(corridor_simulation):
     for _ in range(20):
         sim.iterate()
 
-    state = sim.agent(agent_id).model
+    state = sim.agent(agent_id).state
     assert isinstance(state, PythonSocialForceModelState)
     assert state.desired_speed == 2.0
     assert state.reaction_time == 0.25

--- a/systemtest/test_desired_speed.py
+++ b/systemtest/test_desired_speed.py
@@ -67,7 +67,7 @@ def test_desired_speed_can_be_set_via_state(
         ),
     )
 
-    assert sim.agent(agent_id).model.desired_speed == 1.5
+    assert sim.agent(agent_id).state.desired_speed == 1.5
 
 
 @pytest.mark.parametrize(
@@ -91,9 +91,9 @@ def test_desired_speed_can_be_mutated_via_agent_handle(
         state=state_class(position=(1, 1), **extra_state_kwargs),
     )
 
-    sim.agent(agent_id).model.desired_speed = 1.5
+    sim.agent(agent_id).state.desired_speed = 1.5
 
-    assert sim.agent(agent_id).model.desired_speed == 1.5
+    assert sim.agent(agent_id).state.desired_speed == 1.5
 
 
 @pytest.mark.parametrize(

--- a/systemtest/test_model_constraints.py
+++ b/systemtest/test_model_constraints.py
@@ -1022,7 +1022,7 @@ class _MinimalCustomState:
 
 
 class _MinimalCustomModel(jps.CustomOperationalModel):
-    def compute_next_state(self, dt, ped, env_query):
+    def compute_next_state(self, dt, ped, destination, env_query):
         return _MinimalCustomState(position=ped.position)
 
 
@@ -1083,12 +1083,12 @@ class _NoPositionState:
 
 
 class _NoPositionModel(jps.CustomOperationalModel):
-    def compute_next_state(self, dt, ped, env_query):
+    def compute_next_state(self, dt, ped, destination, env_query):
         return _NoPositionState()
 
 
 class _WrongPositionTypeModel(jps.CustomOperationalModel):
-    def compute_next_state(self, dt, ped, env_query):
+    def compute_next_state(self, dt, ped, destination, env_query):
         return _MinimalCustomState(position="not-a-tuple")
 
 
@@ -1136,7 +1136,7 @@ class _AddAgentDuringIterateModel(jps.CustomOperationalModel):
         self.stage_id = None
         self.error = None
 
-    def compute_next_state(self, dt, ped, env_query):
+    def compute_next_state(self, dt, ped, destination, env_query):
         try:
             self.simulation.add_agent(
                 journey_id=self.journey_id,

--- a/systemtest/test_model_properties.py
+++ b/systemtest/test_model_properties.py
@@ -90,7 +90,7 @@ def test_set_desired_speed(corridor):
     for _ in range(0, 100):
         sim.iterate()
     assert math.isclose(sim.agent(agent_id).position[0], 3)
-    sim.agent(agent_id).model.desired_speed = 2
+    sim.agent(agent_id).state.desired_speed = 2
     for _ in range(0, 100):
         sim.iterate()
     assert math.isclose(sim.agent(agent_id).position[0], 5)
@@ -127,7 +127,7 @@ def test_initial_parameters_collision_free_speed_model_v2(
     )
     agent_id = sim.add_agent(journey_id=journey_id, stage_id=wp, state=state)
 
-    agent_model = sim.agent(agent_id).model
+    agent_model = sim.agent(agent_id).state
     assert agent_model.time_gap == 0.1, (
         f"Expected time_gap to be 0.1, got {agent_model.time_gap}"
     )
@@ -164,29 +164,29 @@ def test_set_model_parameters_collision_free_speed_model_v2(
         state=jps.CollisionFreeSpeedModelV2State(position=(1, 1)),
     )
 
-    sim.agent(agent_id).model.desired_speed = 2.0
-    assert sim.agent(agent_id).model.desired_speed == 2.0
+    sim.agent(agent_id).state.desired_speed = 2.0
+    assert sim.agent(agent_id).state.desired_speed == 2.0
 
-    sim.agent(agent_id).model.desired_speed = 2.1
-    assert sim.agent(agent_id).model.desired_speed == 2.1
+    sim.agent(agent_id).state.desired_speed = 2.1
+    assert sim.agent(agent_id).state.desired_speed == 2.1
 
-    sim.agent(agent_id).model.time_gap = 3.0
-    assert sim.agent(agent_id).model.time_gap == 3.0
+    sim.agent(agent_id).state.time_gap = 3.0
+    assert sim.agent(agent_id).state.time_gap == 3.0
 
-    sim.agent(agent_id).model.radius = 4.0
-    assert sim.agent(agent_id).model.radius == 4.0
+    sim.agent(agent_id).state.radius = 4.0
+    assert sim.agent(agent_id).state.radius == 4.0
 
-    sim.agent(agent_id).model.strength_neighbor_repulsion = 5.0
-    assert sim.agent(agent_id).model.strength_neighbor_repulsion == 5.0
+    sim.agent(agent_id).state.strength_neighbor_repulsion = 5.0
+    assert sim.agent(agent_id).state.strength_neighbor_repulsion == 5.0
 
-    sim.agent(agent_id).model.range_neighbor_repulsion = 6.0
-    assert sim.agent(agent_id).model.range_neighbor_repulsion == 6.0
+    sim.agent(agent_id).state.range_neighbor_repulsion = 6.0
+    assert sim.agent(agent_id).state.range_neighbor_repulsion == 6.0
 
-    sim.agent(agent_id).model.range_geometry_repulsion = 7.0
-    assert sim.agent(agent_id).model.range_geometry_repulsion == 7.0
+    sim.agent(agent_id).state.range_geometry_repulsion = 7.0
+    assert sim.agent(agent_id).state.range_geometry_repulsion == 7.0
 
-    sim.agent(agent_id).model.range_geometry_repulsion = 8.0
-    assert sim.agent(agent_id).model.range_geometry_repulsion == 8.0
+    sim.agent(agent_id).state.range_geometry_repulsion = 8.0
+    assert sim.agent(agent_id).state.range_geometry_repulsion == 8.0
 
 
 @pytest.fixture
@@ -210,32 +210,32 @@ def test_set_model_parameters_anticipation_velocity_model(
         state=jps.AnticipationVelocityModelState(position=(1, 1)),
     )
 
-    sim.agent(agent_id).model.desired_speed = 2.0
-    assert sim.agent(agent_id).model.desired_speed == 2.0
+    sim.agent(agent_id).state.desired_speed = 2.0
+    assert sim.agent(agent_id).state.desired_speed == 2.0
 
-    sim.agent(agent_id).model.desired_speed = 2.1
-    assert sim.agent(agent_id).model.desired_speed == 2.1
+    sim.agent(agent_id).state.desired_speed = 2.1
+    assert sim.agent(agent_id).state.desired_speed == 2.1
 
-    sim.agent(agent_id).model.time_gap = 3.0
-    assert sim.agent(agent_id).model.time_gap == 3.0
+    sim.agent(agent_id).state.time_gap = 3.0
+    assert sim.agent(agent_id).state.time_gap == 3.0
 
-    sim.agent(agent_id).model.radius = 4.0
-    assert sim.agent(agent_id).model.radius == 4.0
+    sim.agent(agent_id).state.radius = 4.0
+    assert sim.agent(agent_id).state.radius == 4.0
 
-    sim.agent(agent_id).model.strength_neighbor_repulsion = 5.0
-    assert sim.agent(agent_id).model.strength_neighbor_repulsion == 5.0
+    sim.agent(agent_id).state.strength_neighbor_repulsion = 5.0
+    assert sim.agent(agent_id).state.strength_neighbor_repulsion == 5.0
 
-    sim.agent(agent_id).model.range_neighbor_repulsion = 6.0
-    assert sim.agent(agent_id).model.range_neighbor_repulsion == 6.0
+    sim.agent(agent_id).state.range_neighbor_repulsion = 6.0
+    assert sim.agent(agent_id).state.range_neighbor_repulsion == 6.0
 
-    sim.agent(agent_id).model.wall_buffer_distance = 1.1
-    assert sim.agent(agent_id).model.wall_buffer_distance == 1.1
+    sim.agent(agent_id).state.wall_buffer_distance = 1.1
+    assert sim.agent(agent_id).state.wall_buffer_distance == 1.1
 
-    sim.agent(agent_id).model.anticipation_time = 2.1
-    assert sim.agent(agent_id).model.anticipation_time == 2.1
+    sim.agent(agent_id).state.anticipation_time = 2.1
+    assert sim.agent(agent_id).state.anticipation_time == 2.1
 
-    sim.agent(agent_id).model.reaction_time = 0.31
-    assert sim.agent(agent_id).model.reaction_time == 0.31
+    sim.agent(agent_id).state.reaction_time = 0.31
+    assert sim.agent(agent_id).state.reaction_time == 0.31
 
 
 @pytest.fixture
@@ -259,17 +259,17 @@ def test_set_model_parameters_collision_free_speed_model(
         state=jps.CollisionFreeSpeedModelState(position=(1, 1)),
     )
 
-    sim.agent(agent_id).model.desired_speed = 2.0
-    assert sim.agent(agent_id).model.desired_speed == 2.0
+    sim.agent(agent_id).state.desired_speed = 2.0
+    assert sim.agent(agent_id).state.desired_speed == 2.0
 
-    sim.agent(agent_id).model.desired_speed = 2.1
-    assert sim.agent(agent_id).model.desired_speed == 2.1
+    sim.agent(agent_id).state.desired_speed = 2.1
+    assert sim.agent(agent_id).state.desired_speed == 2.1
 
-    sim.agent(agent_id).model.time_gap = 3.0
-    assert sim.agent(agent_id).model.time_gap == 3.0
+    sim.agent(agent_id).state.time_gap = 3.0
+    assert sim.agent(agent_id).state.time_gap == 3.0
 
-    sim.agent(agent_id).model.radius = 4.0
-    assert sim.agent(agent_id).model.radius == 4.0
+    sim.agent(agent_id).state.radius = 4.0
+    assert sim.agent(agent_id).state.radius == 4.0
 
 
 def test_collision_free_speed_model_repulsion_parameters_are_model_level():
@@ -293,7 +293,7 @@ def test_collision_free_speed_model_repulsion_parameters_are_model_level():
     )
 
     # The repulsion parameters no longer appear on the per-agent state.
-    agent_model = sim.agent(agent_id).model
+    agent_model = sim.agent(agent_id).state
     for field in (
         "strength_neighbor_repulsion",
         "range_neighbor_repulsion",
@@ -338,32 +338,32 @@ def test_set_model_parameters_generalized_centrifugal_force_model(
         ),
     )
 
-    sim.agent(agent_id).model.speed = 2.0
-    assert sim.agent(agent_id).model.speed == 2.0
+    sim.agent(agent_id).state.speed = 2.0
+    assert sim.agent(agent_id).state.speed == 2.0
 
-    sim.agent(agent_id).model.desired_direction = (3.0, -3.0)
-    assert sim.agent(agent_id).model.desired_direction == (3.0, -3.0)
+    sim.agent(agent_id).state.desired_direction = (3.0, -3.0)
+    assert sim.agent(agent_id).state.desired_direction == (3.0, -3.0)
 
-    sim.agent(agent_id).model.tau = 4.0
-    assert sim.agent(agent_id).model.tau == 4.0
+    sim.agent(agent_id).state.tau = 4.0
+    assert sim.agent(agent_id).state.tau == 4.0
 
-    sim.agent(agent_id).model.desired_speed = 5.0
-    assert sim.agent(agent_id).model.desired_speed == 5.0
+    sim.agent(agent_id).state.desired_speed = 5.0
+    assert sim.agent(agent_id).state.desired_speed == 5.0
 
-    sim.agent(agent_id).model.desired_speed = 5.1
-    assert sim.agent(agent_id).model.desired_speed == 5.1
+    sim.agent(agent_id).state.desired_speed = 5.1
+    assert sim.agent(agent_id).state.desired_speed == 5.1
 
-    sim.agent(agent_id).model.a_v = 6.0
-    assert sim.agent(agent_id).model.a_v == 6.0
+    sim.agent(agent_id).state.a_v = 6.0
+    assert sim.agent(agent_id).state.a_v == 6.0
 
-    sim.agent(agent_id).model.a_min = 7.0
-    assert sim.agent(agent_id).model.a_min == 7.0
+    sim.agent(agent_id).state.a_min = 7.0
+    assert sim.agent(agent_id).state.a_min == 7.0
 
-    sim.agent(agent_id).model.b_min = 8.0
-    assert sim.agent(agent_id).model.b_min == 8.0
+    sim.agent(agent_id).state.b_min = 8.0
+    assert sim.agent(agent_id).state.b_min == 8.0
 
-    sim.agent(agent_id).model.b_max = 9.0
-    assert sim.agent(agent_id).model.b_max == 9.0
+    sim.agent(agent_id).state.b_max = 9.0
+    assert sim.agent(agent_id).state.b_max == 9.0
 
 
 @pytest.fixture
@@ -388,29 +388,29 @@ def test_set_model_parameters_social_force_model(
         state=jps.SocialForceModelState(position=(1, 1)),
     )
 
-    sim.agent(agent_id).model.velocity = (2.0, -2.0)
-    assert sim.agent(agent_id).model.velocity == (2.0, -2.0)
+    sim.agent(agent_id).state.velocity = (2.0, -2.0)
+    assert sim.agent(agent_id).state.velocity == (2.0, -2.0)
 
-    sim.agent(agent_id).model.mass = 3.0
-    assert sim.agent(agent_id).model.mass == 3.0
+    sim.agent(agent_id).state.mass = 3.0
+    assert sim.agent(agent_id).state.mass == 3.0
 
-    sim.agent(agent_id).model.desired_speed = 4.0
-    assert sim.agent(agent_id).model.desired_speed == 4.0
+    sim.agent(agent_id).state.desired_speed = 4.0
+    assert sim.agent(agent_id).state.desired_speed == 4.0
 
-    sim.agent(agent_id).model.reaction_time = 5.0
-    assert sim.agent(agent_id).model.reaction_time == 5.0
+    sim.agent(agent_id).state.reaction_time = 5.0
+    assert sim.agent(agent_id).state.reaction_time == 5.0
 
-    sim.agent(agent_id).model.agent_scale = 6.0
-    assert sim.agent(agent_id).model.agent_scale == 6.0
+    sim.agent(agent_id).state.agent_scale = 6.0
+    assert sim.agent(agent_id).state.agent_scale == 6.0
 
-    sim.agent(agent_id).model.obstacle_scale = 7.0
-    assert sim.agent(agent_id).model.obstacle_scale == 7.0
+    sim.agent(agent_id).state.obstacle_scale = 7.0
+    assert sim.agent(agent_id).state.obstacle_scale == 7.0
 
-    sim.agent(agent_id).model.force_distance = 8.0
-    assert sim.agent(agent_id).model.force_distance == 8.0
+    sim.agent(agent_id).state.force_distance = 8.0
+    assert sim.agent(agent_id).state.force_distance == 8.0
 
-    sim.agent(agent_id).model.radius = 9.0
-    assert sim.agent(agent_id).model.radius == 9.0
+    sim.agent(agent_id).state.radius = 9.0
+    assert sim.agent(agent_id).state.radius == 9.0
 
 
 def test_social_force_model_body_force_and_friction_are_model_level():
@@ -429,7 +429,7 @@ def test_social_force_model_body_force_and_friction_are_model_level():
     )
 
     # body_force and friction no longer appear on the per-agent state.
-    agent_model = sim.agent(agent_id).model
+    agent_model = sim.agent(agent_id).state
     assert not hasattr(agent_model, "body_force")
     assert not hasattr(agent_model, "friction")
 
@@ -461,7 +461,7 @@ def test_agent_handle_raises_after_removal(
     with pytest.raises(jps.SimulationError):
         state.position
     with pytest.raises(jps.SimulationError):
-        state.model.desired_speed
+        state.state.desired_speed
     with pytest.raises(jps.SimulationError):
         state.desired_speed
     with pytest.raises(jps.SimulationError):
@@ -501,7 +501,7 @@ def test_initial_parameters_collision_free_speed_model_v3(
     )
     agent_id = sim.add_agent(journey_id=journey_id, stage_id=wp, state=state)
 
-    agent_model = sim.agent(agent_id).model
+    agent_model = sim.agent(agent_id).state
     assert agent_model.time_gap == 0.11
     assert agent_model.desired_speed == 0.12
     assert agent_model.radius == 0.13
@@ -533,7 +533,7 @@ def test_set_model_parameters_collision_free_speed_model_v3(
             range_geometry_repulsion=0.02,
         ),
     )
-    model = sim.agent(agent_id).model
+    model = sim.agent(agent_id).state
 
     model.desired_speed = 2.0
     assert model.desired_speed == 2.0

--- a/systemtest/test_model_properties.py
+++ b/systemtest/test_model_properties.py
@@ -452,20 +452,20 @@ def test_agent_handle_raises_after_removal(
         state=jps.SocialForceModelState(position=(1, 1)),
     )
     agent = sim.agent(agent_id)
-    model = agent.model
+    state = agent.state
     assert agent.position == (1, 1)
 
     sim.mark_agent_for_removal(agent_id)
     sim.iterate()
 
     with pytest.raises(jps.SimulationError):
-        agent.position
+        state.position
     with pytest.raises(jps.SimulationError):
-        agent.model.desired_speed
+        state.model.desired_speed
     with pytest.raises(jps.SimulationError):
-        model.desired_speed
+        state.desired_speed
     with pytest.raises(jps.SimulationError):
-        model.desired_speed = 1.0
+        state.desired_speed = 1.0
     with pytest.raises(jps.SimulationError):
         sim.agent(agent_id)
 

--- a/systemtest/test_warp_driver.py
+++ b/systemtest/test_warp_driver.py
@@ -147,15 +147,15 @@ def test_agent_parameters():
         ),
     )
 
-    state = sim.agent(aid).model
+    state = sim.agent(aid).state
     assert math.isclose(state.radius, 0.2)
     assert math.isclose(state.desired_speed, 1.0)
 
     # Mutate radius and desired_speed
     state.radius = 0.3
     state.desired_speed = 1.5
-    assert math.isclose(sim.agent(aid).model.radius, 0.3)
-    assert math.isclose(sim.agent(aid).model.desired_speed, 1.5)
+    assert math.isclose(sim.agent(aid).state.radius, 0.3)
+    assert math.isclose(sim.agent(aid).state.desired_speed, 1.5)
 
 
 def test_invalid_agent_state():


### PR DESCRIPTION
The purpose of this PR is to change the ComputeNextState and CheckModelConstraint function in the operational models to use OperationalModelStates instead of GenericAgents this unwrapping helps with future work on combining operational models. 
An effect of this change is also changing the function software the actual model to accept the state of that model and use it directly with using `std::get` in every function but rather only once.
The Python bindings and interface are changed accordingly.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1631/
<!-- PREVIEW-URL-END -->