### PR TITLE
Fixes #1624: Fix RST markup in Python API docstrings.

### DIFF
--- a/python_modules/jupedsim/jupedsim/distributions.py
+++ b/python_modules/jupedsim/jupedsim/distributions.py
@@ -260,7 +260,7 @@ def distribute_in_circles_by_number(
 
     This function will generate 2D coordinates in the intersection of the
     polygon and the rings specified by the centerpoint and the min/max radii of
-    each ring. `number_of_agents` is expected to contain the number of agents
+    each ring. ``number_of_agents`` is expected to contain the number of agents
     to be placed for each ring. This function may not always be able to
     generate the requested coordinate because it cannot do so without violating
     the constraints. In this case the function will stop after max_iterations
@@ -622,13 +622,19 @@ def distribute_by_percentage(
 
 
 def __check_distance_constraints(pt, wall_distance, grid, polygon):
-    """Determines if a point has enough distance to other points and to the walls
-     Uses a Grid to determine neighbours
-    :param grid: the grid of the polygon
-    :param pt: point that is being checked
-    :param wall_distance: minimal distance between point and the polygon
-    :param polygon: shapely Polygon in which the points must lie
-    :return:True or False"""
+    """Determines if a point has enough distance to other points and to the walls.
+
+    Uses a Grid to determine neighbours.
+
+    Arguments:
+        pt: point that is being checked
+        wall_distance: minimal distance between point and the polygon
+        grid: the grid of the polygon
+        polygon: shapely Polygon in which the points must lie
+
+    Returns:
+        True or False
+    """
     if not polygon.contains(shapely.Point(pt)):
         return False
     if __min_distance_to_polygon(pt, polygon) < wall_distance:
@@ -637,11 +643,16 @@ def __check_distance_constraints(pt, wall_distance, grid, polygon):
 
 
 def __box_of_intersection(polygon, center_point, outer_radius):
-    """returns an Axis Aligned Bounding Box containing the intersection of a Circle and the polygon
-     @:param polygon is a shapely Polygon
-     @:param center_point is the Center point of the Circle
-    @:param outer_radius is the radius of the Circle
-    @:return bounding box formatted like [(min(x_values), min(y_values)), (max(x_values), max(y_values))]
+    """Axis Aligned Bounding Box containing the intersection of a circle and the polygon.
+
+    Arguments:
+        polygon: a shapely Polygon
+        center_point: the center point of the circle
+        outer_radius: the radius of the circle
+
+    Returns:
+        bounding box formatted like
+        [(min(x_values), min(y_values)), (max(x_values), max(y_values))]
     """
     # creates a point
     point = shapely.Point(center_point)

--- a/python_modules/jupedsim/jupedsim/geometry_utils.py
+++ b/python_modules/jupedsim/jupedsim/geometry_utils.py
@@ -137,7 +137,7 @@ def build_geometry(
     Arguments:
         geometry: Data to create the geometry out of. Data may be supplied as:
 
-            * list of 2d points describing the outer boundary, holes may be added with use of `excluded_areas` kw-argument
+            * list of 2d points describing the outer boundary, holes may be added with use of ``excluded_areas`` kw-argument
 
             * :class:`~shapely.GeometryCollection` consisting only out of :class:`Polygons <shapely.Polygon>`, :class:`MultiPolygons <shapely.MultiPolygon>` and :class:`MultiPoints <shapely.MultiPoint>`
 
@@ -151,7 +151,7 @@ def build_geometry(
 
     Keyword Arguments:
         excluded_areas: describes exclusions
-            from the walkable area. Only use this argument if `geometry` was
+            from the walkable area. Only use this argument if ``geometry`` was
             provided as list[tuple[float, float]].
     """
     if isinstance(geometry, str):

--- a/python_modules/jupedsim/jupedsim/models/anticipation_velocity_model.py
+++ b/python_modules/jupedsim/jupedsim/models/anticipation_velocity_model.py
@@ -11,30 +11,29 @@ class AnticipationVelocityModel:
     """Anticipation Velocity Model (AVM).
 
     The AVM incorporates pedestrian anticipation, divided into three phases:
+
     1. Perception of the current situation.
     2. Prediction of future situations.
     3. Strategy selection leading to action.
 
-    This model quantitatively reproduces bidirectional pedestrian flow by accounting for:
+    This model quantitatively reproduces bidirectional pedestrian flow by
+    accounting for:
+
     - Anticipation of changes in neighboring pedestrians' positions.
-    - The strategy of following others' movement. The AVM is a model that takes into consideration
-      the anticipation of pedestrians. For this, the process of anticipation is divided into three parts:
-      - perception of the actual situation,
-      - prediction of a future situation and
-      - selection of a strategy leading to action.
+    - The strategy of following others' movement.
 
-
-    A general description of the AVM can be found in the originating publication
-    https://doi.org/10.1016/j.trc.2021.103464
+    A general description of the AVM can be found in the originating
+    publication https://doi.org/10.1016/j.trc.2021.103464
 
     Attributes:
-        pushout_strength: The pushout mechanism ensures agents maintain a safe distance
-        from walls by adding a small outward component to their movement when within the
-        critical wall distance. This outward component, scaled by `pushoutStrength`,
-        combines with the parallel component of the agent's direction to create smooth,
-        gliding behavior along walls.
-        rng_seed: seed value of internally used rng. If not explicitly set this
-            value will be chosen randomly.
+        pushout_strength: The pushout mechanism ensures agents maintain a
+            safe distance from walls by adding a small outward component to
+            their movement when within the critical wall distance. This
+            outward component, scaled by ``pushout_strength``, combines with
+            the parallel component of the agent's direction to create
+            smooth, gliding behavior along walls.
+        rng_seed: seed value of internally used rng. If not explicitly set
+            this value will be chosen randomly.
     """
 
     pushout_strength: float = 0.3
@@ -52,7 +51,7 @@ class AnticipationVelocityModelAgentParameters:
     .. note::
 
         Instances of this type are copied when creating the agent, you can safely
-        create one instance of this type and modify it between calls to `add_agent`
+        create one instance of this type and modify it between calls to ``add_agent``
 
         E.g.:
 

--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed.py
@@ -44,7 +44,7 @@ class CollisionFreeSpeedModelAgentParameters:
     .. note::
 
         Instances of this type are copied when creating the agent, you can safely
-        create one instance of this type and modify it between calls to `add_agent`
+        create one instance of this type and modify it between calls to ``add_agent``
 
         E.g.:
 

--- a/python_modules/jupedsim/jupedsim/models/collision_free_speed_v2.py
+++ b/python_modules/jupedsim/jupedsim/models/collision_free_speed_v2.py
@@ -38,7 +38,7 @@ class CollisionFreeSpeedModelV2AgentParameters:
     .. note::
 
         Instances of this type are copied when creating the agent, you can safely
-        create one instance of this type and modify it between calls to `add_agent`
+        create one instance of this type and modify it between calls to ``add_agent``
 
         E.g.:
 

--- a/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
+++ b/python_modules/jupedsim/jupedsim/models/generalized_centrifugal_force.py
@@ -49,7 +49,7 @@ class GeneralizedCentrifugalForceModelAgentParameters:
 
     .. note::
         Instances of this type are copied when creating the agent, you can safely
-        create one instance of this type and modify it between calls to `add_agent`
+        create one instance of this type and modify it between calls to ``add_agent``
 
         E.g.:
 

--- a/python_modules/jupedsim/jupedsim/routing.py
+++ b/python_modules/jupedsim/jupedsim/routing.py
@@ -33,7 +33,7 @@ class RoutingEngine:
         Arguments:
             geometry: Data to create the geometry out of. Data may be supplied as:
 
-                * list of 2d points describing the outer boundary, holes may be added with use of `excluded_areas` kw-argument
+                * list of 2d points describing the outer boundary, holes may be added with use of ``excluded_areas`` kw-argument
 
                 * :class:`~shapely.GeometryCollection` consisting only out of :class:`Polygons <shapely.Polygon>`, :class:`MultiPolygons <shapely.MultiPolygon>` and :class:`MultiPoints <shapely.MultiPoint>`
 
@@ -50,7 +50,7 @@ class RoutingEngine:
 
         Keyword Arguments:
             excluded_areas: describes exclusions
-                from the walkable area. Only use this argument if `geometry` was
+                from the walkable area. Only use this argument if ``geometry`` was
                 provided as list[tuple[float, float]].
 
         Returns:

--- a/python_modules/jupedsim/jupedsim/simulation.py
+++ b/python_modules/jupedsim/jupedsim/simulation.py
@@ -89,7 +89,7 @@ class Simulation:
             geometry:
                 Data to create the geometry out of. Data may be supplied as:
 
-                * list of 2d points describing the outer boundary, holes may be added with use of `excluded_areas` kw-argument
+                * list of 2d points describing the outer boundary, holes may be added with use of ``excluded_areas`` kw-argument
 
                 * :class:`~shapely.GeometryCollection` consisting only out of :class:`Polygons <shapely.Polygon>`, :class:`MultiPolygons <shapely.MultiPolygon>` and :class:`MultiPoints <shapely.MultiPoint>`
 
@@ -110,7 +110,7 @@ class Simulation:
 
         Keyword Arguments:
             excluded_areas: describes exclusions
-                from the walkable area. Only use this argument if `geometry` was
+                from the walkable area. Only use this argument if ``geometry`` was
                 provided as list[tuple[float, float]].
         """
         if isinstance(model, CollisionFreeSpeedModel):

--- a/python_modules/jupedsim/jupedsim/stages.py
+++ b/python_modules/jupedsim/jupedsim/stages.py
@@ -39,7 +39,7 @@ class NotifiableQueueStage:
         return self._obj.count_enqueued()
 
     def pop(self, count) -> None:
-        """Pop `count` number of agents from the front of the queue.
+        """Pop ``count`` number of agents from the front of the queue.
 
         Arguments:
             count: Number of agents to be popped from the front of the


### PR DESCRIPTION
- Fixes to AVM model docstring that caused bad rendering of "pushout_strength" parameter.
- Inline code written with single backticks renders as italics --> changed to double backticks everywhere.
- Fixed two private helper docstrings using Javadoc-style.