### PR TITLE
Avoid recomputing walls for every neighbor in range call

### DIFF
--- a/libsimulator/src/EnvironmentQuery.hpp
+++ b/libsimulator/src/EnvironmentQuery.hpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <concepts>
 #include <iterator>
+#include <optional>
 #include <ranges>
 #include <vector>
 
@@ -20,6 +21,15 @@ class EnvironmentQuery
 {
     const CollisionGeometry& _geometry;
     const NeighborhoodSearch<GenericAgent>& _nsearch;
+    mutable std::optional<Point> _cached_boundary_pos{};
+    mutable std::vector<LineSegment> _cached_boundary{};
+
+    void _fetchBoundaryAt(const Point& from) const
+    {
+        _cached_boundary_pos = from;
+        auto range = _geometry.LineSegmentsInApproxDistanceTo(from);
+        _cached_boundary.assign(range.begin(), range.end());
+    }
 
 public:
     EnvironmentQuery(
@@ -42,9 +52,11 @@ public:
     std::vector<GenericAgent>
     OtherAgentsInRange(const OperationalModelState& state, double radius, Pred filter = {}) const
     {
+        const Point from = Pos(state);
+        _fetchBoundaryAt(from);
         std::vector<GenericAgent> neighbors{};
-        _nsearch.ForEachInRange(Pos(state), radius, [&](const GenericAgent& candidate) {
-            if(candidate.position() != Pos(state) && filter(candidate.position())) {
+        _nsearch.ForEachInRange(from, radius, [&](const GenericAgent& candidate) {
+            if(candidate.position() != from && filter(candidate.position())) {
                 neighbors.push_back(candidate);
             }
         });
@@ -66,14 +78,14 @@ public:
 
     bool NoGeometryBetween(const Point& from, const Point& to) const
     {
+        if(!_cached_boundary_pos || *_cached_boundary_pos != from) {
+            _fetchBoundaryAt(from);
+        }
         const LineSegment los{from, to};
-        const double dist = Distance(from, to);
-        auto blocked = [&los](const auto& boundaries) {
-            return std::any_of(boundaries.begin(), boundaries.end(), [&los](const auto& seg) {
+        return !std::any_of(
+            _cached_boundary.begin(), _cached_boundary.end(), [&los](const auto& seg) {
                 return intersects(los, seg);
             });
-        };
-        return !blocked(LineSegmentsInRange(from, dist));
     }
 
     CollisionGeometry::LineSegmentRange

--- a/libsimulator/src/EnvironmentQuery.hpp
+++ b/libsimulator/src/EnvironmentQuery.hpp
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <concepts>
 #include <iterator>
-#include <optional>
 #include <ranges>
 #include <vector>
 
@@ -21,15 +20,6 @@ class EnvironmentQuery
 {
     const CollisionGeometry& _geometry;
     const NeighborhoodSearch<GenericAgent>& _nsearch;
-    mutable std::optional<Point> _cached_boundary_pos{};
-    mutable std::vector<LineSegment> _cached_boundary{};
-
-    void _fetchBoundaryAt(const Point& from) const
-    {
-        _cached_boundary_pos = from;
-        auto range = _geometry.LineSegmentsInApproxDistanceTo(from);
-        _cached_boundary.assign(range.begin(), range.end());
-    }
 
 public:
     EnvironmentQuery(
@@ -46,14 +36,14 @@ public:
     // Returns all agents within 'radius' of 'agent', excluding 'agent' itself.
     // An optional predicate 'filter' further filters the result; it receives the
     // position for which neighbors are returned as well as the candidates. Example:
-    //   query.AgentsInRange(state, r, [&envQuery, from=model.position](const Point& to) {
-    //   return envQuery.NoGeometryBetween(from, to);})
+    //   const auto& boundary = query.LineSegmentsInRange(Pos(state));
+    //   query.OtherAgentsInRange(state, r, [&](const Point& to) {
+    //   return query.NoGeometryBetween(from, to, boundary);})
     template <std::predicate<const Point&> Pred = AcceptAll>
     std::vector<GenericAgent>
     OtherAgentsInRange(const OperationalModelState& state, double radius, Pred filter = {}) const
     {
         const Point from = Pos(state);
-        _fetchBoundaryAt(from);
         std::vector<GenericAgent> neighbors{};
         _nsearch.ForEachInRange(from, radius, [&](const GenericAgent& candidate) {
             if(candidate.position() != from && filter(candidate.position())) {
@@ -76,16 +66,15 @@ public:
         return neighbors;
     }
 
-    bool NoGeometryBetween(const Point& from, const Point& to) const
+    bool NoGeometryBetween(
+        const Point& from,
+        const Point& to,
+        const CollisionGeometry::LineSegmentRange& boundary) const
     {
-        if(!_cached_boundary_pos || *_cached_boundary_pos != from) {
-            _fetchBoundaryAt(from);
-        }
         const LineSegment los{from, to};
-        return !std::any_of(
-            _cached_boundary.begin(), _cached_boundary.end(), [&los](const auto& seg) {
-                return intersects(los, seg);
-            });
+        return !std::any_of(boundary.begin(), boundary.end(), [&los](const auto& seg) {
+            return intersects(los, seg);
+        });
     }
 
     CollisionGeometry::LineSegmentRange

--- a/libsimulator/src/EnvironmentQuery.hpp
+++ b/libsimulator/src/EnvironmentQuery.hpp
@@ -36,9 +36,9 @@ public:
     // Returns all agents within 'radius' of 'agent', excluding 'agent' itself.
     // An optional predicate 'filter' further filters the result; it receives the
     // position for which neighbors are returned as well as the candidates. Example:
-    //   const auto& boundary = query.LineSegmentsInRange(Pos(state));
+    //   const auto& boundaries = query.LineSegmentsInRange(Pos(state));
     //   query.OtherAgentsInRange(state, r, [&](const Point& to) {
-    //   return query.NoGeometryBetween(from, to, boundary);})
+    //   return query.NoGeometryBetween(from, to, boundaries);})
     template <std::predicate<const Point&> Pred = AcceptAll>
     std::vector<GenericAgent>
     OtherAgentsInRange(const OperationalModelState& state, double radius, Pred filter = {}) const
@@ -69,10 +69,10 @@ public:
     bool NoGeometryBetween(
         const Point& from,
         const Point& to,
-        const CollisionGeometry::LineSegmentRange& boundary) const
+        const CollisionGeometry::LineSegmentRange& boundaries) const
     {
         const LineSegment los{from, to};
-        return !std::any_of(boundary.begin(), boundary.end(), [&los](const auto& seg) {
+        return !std::any_of(boundaries.begin(), boundaries.end(), [&los](const auto& seg) {
             return intersects(los, seg);
         });
     }

--- a/libsimulator/src/EnvironmentQuery.hpp
+++ b/libsimulator/src/EnvironmentQuery.hpp
@@ -66,13 +66,11 @@ public:
         return neighbors;
     }
 
-    bool NoGeometryBetween(
-        const Point& from,
-        const Point& to,
-        const CollisionGeometry::LineSegmentRange& boundaries) const
+    template <typename Range>
+    bool NoGeometryBetween(const Point& from, const Point& to, const Range& boundaries) const
     {
         const LineSegment los{from, to};
-        return !std::any_of(boundaries.begin(), boundaries.end(), [&los](const auto& seg) {
+        return !std::any_of(std::begin(boundaries), std::end(boundaries), [&los](const auto& seg) {
             return intersects(los, seg);
         });
     }

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
@@ -39,8 +39,8 @@ void AnticipationVelocityModel::ComputeNextState(
     const auto& boundary = envQuery.LineSegmentsInRange(model.position);
     // Exclude occluded and self agents
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to);
+        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundary);
         });
 
     const auto neighborRepulsion = std::accumulate(

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
@@ -36,11 +36,11 @@ void AnticipationVelocityModel::ComputeNextState(
     const EnvironmentQuery& envQuery) const
 {
     const auto& model = std::get<State>(current.model);
-    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
+    const auto& boundaries = envQuery.LineSegmentsInRange(model.position);
     // Exclude occluded and self agents
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to, boundary);
+        model, _cutOffRadius, [&envQuery, &boundaries, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundaries);
         });
 
     const auto neighborRepulsion = std::accumulate(
@@ -72,7 +72,7 @@ void AnticipationVelocityModel::ComputeNextState(
 
     const auto optimal_speed = OptimalSpeed(current, spacing, model.timeGap);
     direction = HandleWallAvoidance(
-        direction, model.position, model.radius, boundary, wallBufferDistance, _pushoutStrength);
+        direction, model.position, model.radius, boundaries, wallBufferDistance, _pushoutStrength);
 
     const auto velocity = direction * optimal_speed;
     auto& nextModel = std::get<State>(next.model);
@@ -278,7 +278,7 @@ Point AnticipationVelocityModel::HandleWallAvoidance(
     const Point& direction,
     const Point& agentPosition,
     double agentRadius,
-    const auto& boundary,
+    const auto& boundaries,
     double wallBufferDistance,
     double pushoutStrength) const
 {
@@ -286,8 +286,8 @@ Point AnticipationVelocityModel::HandleWallAvoidance(
 
     Point modifiedDirection = direction;
     std::for_each(
-        std::begin(boundary),
-        std::end(boundary),
+        std::begin(boundaries),
+        std::end(boundaries),
         [&agentPosition, &criticalWallDistance, &modifiedDirection, pushoutStrength](
             const LineSegment& wall) {
             const auto closestPoint = wall.ShortestPoint(agentPosition);

--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.hpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.hpp
@@ -63,7 +63,7 @@ private:
         const Point& direction,
         const Point& agentPosition,
         double agentRadius,
-        const auto& boundary,
+        const auto& boundaries,
         double wallBufferDistance,
         double pushoutStrength) const;
 

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
@@ -43,8 +43,8 @@ void CollisionFreeSpeedModel::ComputeNextState(
     const auto& model = std::get<State>(current.model);
     const auto& boundary = envQuery.LineSegmentsInRange(model.position);
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to);
+        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundary);
         });
 
     const auto neighborRepulsion = std::accumulate(

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
@@ -41,10 +41,10 @@ void CollisionFreeSpeedModel::ComputeNextState(
     const EnvironmentQuery& envQuery) const
 {
     const auto& model = std::get<State>(current.model);
-    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
+    const auto& boundaries = envQuery.LineSegmentsInRange(model.position);
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to, boundary);
+        model, _cutOffRadius, [&envQuery, &boundaries, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundaries);
         });
 
     const auto neighborRepulsion = std::accumulate(
@@ -56,8 +56,8 @@ void CollisionFreeSpeedModel::ComputeNextState(
         });
 
     const auto boundaryRepulsion = std::accumulate(
-        std::begin(boundary),
-        std::end(boundary),
+        std::begin(boundaries),
+        std::end(boundaries),
         Point(0, 0),
         [this, &current](const auto& acc, const auto& element) {
             return acc + BoundaryRepulsion(current, element);

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
@@ -31,8 +31,8 @@ void CollisionFreeSpeedModelV2::ComputeNextState(
     const auto& model = std::get<State>(current.model);
     const auto& boundary = envQuery.LineSegmentsInRange(model.position);
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to);
+        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundary);
         });
 
     const auto neighborRepulsion = std::accumulate(

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
@@ -29,10 +29,10 @@ void CollisionFreeSpeedModelV2::ComputeNextState(
     const EnvironmentQuery& envQuery) const
 {
     const auto& model = std::get<State>(current.model);
-    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
+    const auto& boundaries = envQuery.LineSegmentsInRange(model.position);
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to, boundary);
+        model, _cutOffRadius, [&envQuery, &boundaries, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundaries);
         });
 
     const auto neighborRepulsion = std::accumulate(
@@ -44,8 +44,8 @@ void CollisionFreeSpeedModelV2::ComputeNextState(
         });
 
     const auto boundaryRepulsion = std::accumulate(
-        std::begin(boundary),
-        std::end(boundary),
+        std::begin(boundaries),
+        std::end(boundaries),
         Point(0, 0),
         [this, &current](const auto& acc, const auto& element) {
             return acc + BoundaryRepulsion(current, element);

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
@@ -76,8 +76,8 @@ void CollisionFreeSpeedModelV3::ComputeNextState(
     const auto& model = std::get<State>(current.model);
     const auto& boundary = envQuery.LineSegmentsInRange(model.position);
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to);
+        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundary);
         });
 
     const auto boundaryRepulsion = std::accumulate(

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
@@ -74,15 +74,15 @@ void CollisionFreeSpeedModelV3::ComputeNextState(
     const EnvironmentQuery& envQuery) const
 {
     const auto& model = std::get<State>(current.model);
-    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
+    const auto& boundaries = envQuery.LineSegmentsInRange(model.position);
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to, boundary);
+        model, _cutOffRadius, [&envQuery, &boundaries, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundaries);
         });
 
     const auto boundaryRepulsion = std::accumulate(
-        std::begin(boundary),
-        std::end(boundary),
+        std::begin(boundaries),
+        std::end(boundaries),
         Point(0, 0),
         [this, &current](const auto& acc, const auto& element) {
             return acc + BoundaryRepulsion(current, element);

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -48,10 +48,10 @@ void GeneralizedCentrifugalForceModel::ComputeNextState(
     const EnvironmentQuery& envQuery) const
 {
     const auto& model = std::get<State>(current.model);
-    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
+    const auto& boundaries = envQuery.LineSegmentsInRange(model.position);
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to, boundary);
+        model, _cutOffRadius, [&envQuery, &boundaries, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundaries);
         });
     Point F_rep;
     for(const auto& neighbor : neighborhood) {

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -48,9 +48,10 @@ void GeneralizedCentrifugalForceModel::ComputeNextState(
     const EnvironmentQuery& envQuery) const
 {
     const auto& model = std::get<State>(current.model);
+    const auto& boundary = envQuery.LineSegmentsInRange(model.position);
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to);
+        model, _cutOffRadius, [&envQuery, &boundary, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, boundary);
         });
     Point F_rep;
     for(const auto& neighbor : neighborhood) {

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
@@ -33,16 +33,16 @@ void SocialForceModel::ComputeNextState(
     const auto& model = std::get<State>(current.model);
     auto forces = DrivingForce(current);
 
+    const auto& walls = envQuery.LineSegmentsInRange(model.position);
     auto neighborhood = envQuery.OtherAgentsInRange(
-        model, _cutOffRadius, [&envQuery, from = model.position](const Point& to) {
-            return envQuery.NoGeometryBetween(from, to);
+        model, _cutOffRadius, [&envQuery, &walls, from = model.position](const Point& to) {
+            return envQuery.NoGeometryBetween(from, to, walls);
         });
     Point F_rep;
     for(const auto& neighbor : neighborhood) {
         F_rep += AgentForce(current, neighbor);
     }
     forces += F_rep / model.mass;
-    const auto& walls = envQuery.LineSegmentsInRange(model.position);
 
     const auto obstacle_f = std::accumulate(
         std::begin(walls),

--- a/libsimulator/src/Stage.cpp
+++ b/libsimulator/src/Stage.cpp
@@ -208,8 +208,10 @@ void NotifiableWaitingSet::Update(const EnvironmentQuery& envQuery)
 
     for(size_t index = count_occupants; index < slots.size(); ++index) {
         const auto slot_pos = slots[index];
-        auto candidates = envQuery.AgentsInRange(
-            slot_pos, 2, [&](const Point& to) { return envQuery.NoGeometryBetween(slot_pos, to); });
+        const auto boundary = envQuery.LineSegmentsInRange(slot_pos);
+        auto candidates = envQuery.AgentsInRange(slot_pos, 2, [&](const Point& to) {
+            return envQuery.NoGeometryBetween(slot_pos, to, boundary);
+        });
 
         GenericAgent::ID occupant = GenericAgent::ID::Invalid;
         double min_distance = std::numeric_limits<double>::max();
@@ -290,8 +292,10 @@ void NotifiableQueue::Update(const EnvironmentQuery& envQuery)
 
     for(size_t index = count_occupants; index < slots.size(); ++index) {
         const auto slot_pos = slots[index];
-        auto candidates = envQuery.AgentsInRange(
-            slot_pos, 2, [&](const Point& to) { return envQuery.NoGeometryBetween(slot_pos, to); });
+        const auto boundary = envQuery.LineSegmentsInRange(slot_pos);
+        auto candidates = envQuery.AgentsInRange(slot_pos, 2, [&](const Point& to) {
+            return envQuery.NoGeometryBetween(slot_pos, to, boundary);
+        });
 
         GenericAgent::ID occupant = GenericAgent::ID::Invalid;
         double min_distance = std::numeric_limits<double>::max();

--- a/libsimulator/src/Stage.cpp
+++ b/libsimulator/src/Stage.cpp
@@ -208,9 +208,9 @@ void NotifiableWaitingSet::Update(const EnvironmentQuery& envQuery)
 
     for(size_t index = count_occupants; index < slots.size(); ++index) {
         const auto slot_pos = slots[index];
-        const auto boundary = envQuery.LineSegmentsInRange(slot_pos);
+        const auto boundaries = envQuery.LineSegmentsInRange(slot_pos);
         auto candidates = envQuery.AgentsInRange(slot_pos, 2, [&](const Point& to) {
-            return envQuery.NoGeometryBetween(slot_pos, to, boundary);
+            return envQuery.NoGeometryBetween(slot_pos, to, boundaries);
         });
 
         GenericAgent::ID occupant = GenericAgent::ID::Invalid;
@@ -292,9 +292,9 @@ void NotifiableQueue::Update(const EnvironmentQuery& envQuery)
 
     for(size_t index = count_occupants; index < slots.size(); ++index) {
         const auto slot_pos = slots[index];
-        const auto boundary = envQuery.LineSegmentsInRange(slot_pos);
+        const auto boundaries = envQuery.LineSegmentsInRange(slot_pos);
         auto candidates = envQuery.AgentsInRange(slot_pos, 2, [&](const Point& to) {
-            return envQuery.NoGeometryBetween(slot_pos, to, boundary);
+            return envQuery.NoGeometryBetween(slot_pos, to, boundaries);
         });
 
         GenericAgent::ID occupant = GenericAgent::ID::Invalid;

--- a/libsimulator/test/TestEnvironmentQuery.cpp
+++ b/libsimulator/test/TestEnvironmentQuery.cpp
@@ -124,8 +124,10 @@ TEST(EnvironmentQuery, NoGeometryBetweenFiltersOccludedAgents)
     const auto q = env.query(geo);
 
     const auto from = env.agents[0].position();
-    const auto result = q.OtherAgentsInRange(
-        env.agents[0], 5.0, [&](const Point& to) { return q.NoGeometryBetween(from, to); });
+    const auto boundary = q.LineSegmentsInRange(from, 5.0);
+    const auto result = q.OtherAgentsInRange(env.agents[0], 5.0, [&](const Point& to) {
+        return q.NoGeometryBetween(from, to, boundary);
+    });
 
     ASSERT_EQ(result.size(), 1u);
     EXPECT_EQ(std::get<State>(result[0].model).position, Point(0, 1));

--- a/python_bindings_jupedsim/conversion.hpp
+++ b/python_bindings_jupedsim/conversion.hpp
@@ -39,6 +39,12 @@ auto intoVec(Range&& range)
     return result;
 }
 
+template <typename T>
+auto intoRange(const std::vector<T>& v)
+{
+    return std::ranges::subrange(v.cbegin(), v.cend());
+}
+
 template <typename T, typename U>
 std::vector<T> intoVecT(const std::vector<U>& vec)
 {

--- a/python_bindings_jupedsim/conversion.hpp
+++ b/python_bindings_jupedsim/conversion.hpp
@@ -39,12 +39,6 @@ auto intoVec(Range&& range)
     return result;
 }
 
-template <typename T>
-auto intoRange(const std::vector<T>& v)
-{
-    return std::ranges::subrange(v.cbegin(), v.cend());
-}
-
 template <typename T, typename U>
 std::vector<T> intoVecT(const std::vector<U>& vec)
 {

--- a/python_bindings_jupedsim/environment_query.cpp
+++ b/python_bindings_jupedsim/environment_query.cpp
@@ -27,12 +27,30 @@ void init_environment_query(py::module_& m)
             [](const EnvironmentQuery& self,
                std::tuple<double, double> from,
                std::tuple<double, double> to) -> bool {
-                return self.NoGeometryBetween(intoPoint(from), intoPoint(to));
+                const auto boundary = self.LineSegmentsInRange(intoPoint(from));
+                return self.NoGeometryBetween(intoPoint(from), intoPoint(to), boundary);
             },
             py::arg("from"),
             py::arg("to"),
             "Returns a bool: True when position from has a line-of-sight unobstructed by wall to "
             "the candidate position to.")
+        .def(
+            "no_wall_between",
+            [](const EnvironmentQuery& /*self*/,
+               std::tuple<double, double> from,
+               std::tuple<double, double> to,
+               const std::vector<LineSegment>& boundary) -> bool {
+                const LineSegment los{intoPoint(from), intoPoint(to)};
+                return !std::any_of(boundary.begin(), boundary.end(), [&los](const auto& seg) {
+                    return intersects(los, seg);
+                });
+            },
+            py::arg("from"),
+            py::arg("to"),
+            py::arg("boundary"),
+            "Returns a bool: True when position from has a line-of-sight unobstructed by any "
+            "segment in the pre-fetched boundary. Pass the result of line_segments_in_range() as "
+            "boundary to avoid re-fetching geometry on every call.")
         .def(
             "line_segments_in_range",
             [](const EnvironmentQuery& self, std::tuple<double, double> p, double distance) {

--- a/python_bindings_jupedsim/environment_query.cpp
+++ b/python_bindings_jupedsim/environment_query.cpp
@@ -24,30 +24,18 @@ void init_environment_query(py::module_& m)
             "All agents within radius of agent (self excluded).")
         .def(
             "no_wall_between",
-            [](const EnvironmentQuery& self,
-               std::tuple<double, double> from,
-               std::tuple<double, double> to) -> bool {
-                const auto boundary = self.LineSegmentsInRange(intoPoint(from));
-                return self.NoGeometryBetween(intoPoint(from), intoPoint(to), boundary);
-            },
-            py::arg("from"),
-            py::arg("to"),
-            "Returns a bool: True when position from has a line-of-sight unobstructed by wall to "
-            "the candidate position to.")
-        .def(
-            "no_wall_between",
             [](const EnvironmentQuery& /*self*/,
                std::tuple<double, double> from,
                std::tuple<double, double> to,
-               const std::vector<LineSegment>& boundary) -> bool {
+               const std::vector<LineSegment>& boundaries) -> bool {
                 const LineSegment los{intoPoint(from), intoPoint(to)};
-                return !std::any_of(boundary.begin(), boundary.end(), [&los](const auto& seg) {
+                return !std::any_of(boundaries.begin(), boundaries.end(), [&los](const auto& seg) {
                     return intersects(los, seg);
                 });
             },
             py::arg("from"),
             py::arg("to"),
-            py::arg("boundary"),
+            py::arg("boundaries"),
             "Returns a bool: True when position from has a line-of-sight unobstructed by any "
             "segment in the pre-fetched boundary. Pass the result of line_segments_in_range() as "
             "boundary to avoid re-fetching geometry on every call.")

--- a/python_bindings_jupedsim/environment_query.cpp
+++ b/python_bindings_jupedsim/environment_query.cpp
@@ -28,8 +28,7 @@ void init_environment_query(py::module_& m)
                std::tuple<double, double> from,
                std::tuple<double, double> to,
                const std::vector<LineSegment>& boundaries) {
-                return self.NoGeometryBetween(
-                    intoPoint(from), intoPoint(to), intoRange(boundaries));
+                return self.NoGeometryBetween(intoPoint(from), intoPoint(to), boundaries);
             },
             py::arg("from"),
             py::arg("to"),

--- a/python_bindings_jupedsim/environment_query.cpp
+++ b/python_bindings_jupedsim/environment_query.cpp
@@ -24,14 +24,12 @@ void init_environment_query(py::module_& m)
             "All agents within radius of agent (self excluded).")
         .def(
             "no_wall_between",
-            [](const EnvironmentQuery& /*self*/,
+            [](const EnvironmentQuery& self,
                std::tuple<double, double> from,
                std::tuple<double, double> to,
-               const std::vector<LineSegment>& boundaries) -> bool {
-                const LineSegment los{intoPoint(from), intoPoint(to)};
-                return !std::any_of(boundaries.begin(), boundaries.end(), [&los](const auto& seg) {
-                    return intersects(los, seg);
-                });
+               const std::vector<LineSegment>& boundaries) {
+                return self.NoGeometryBetween(
+                    intoPoint(from), intoPoint(to), intoRange(boundaries));
             },
             py::arg("from"),
             py::arg("to"),

--- a/python_modules/jupedsim/jupedsim/environment_query.py
+++ b/python_modules/jupedsim/jupedsim/environment_query.py
@@ -63,7 +63,7 @@ class EnvironmentQuery:
         self,
         from_pos: tuple[float, float],
         to_pos: tuple[float, float],
-        boundary: list[LineSegment],
+        boundaries: list[LineSegment],
     ) -> bool:
         """Return ``True`` when the straight line from *from_pos* to *to_pos*
         is not intersected by any geometry boundary (i.e. no wall blocks it).
@@ -71,7 +71,7 @@ class EnvironmentQuery:
         Args:
             from_pos: Observer position as ``(x, y)`` in metres.
             to_pos: Target position as ``(x, y)`` in metres.
-            boundary: pre-fetched list of wall segments from
+            boundaries: pre-fetched list of wall segments from
                 :meth:`line_segments_in_range`.
 
         Returns:
@@ -79,14 +79,14 @@ class EnvironmentQuery:
 
         Example — pre-fetch once, reuse for every neighbor::
 
-            walls = env_query.line_segments_in_range(ped.position, cutoff)
+            boundaries = env_query.line_segments_in_range(ped.position, cutoff)
             neighbors = env_query.other_agents_in_range(
                 ped, cutoff,
-                lambda n: env_query.no_wall_between(ped.position, n.position, walls)
+                lambda n: env_query.no_wall_between(ped.position, n.position, boundaries)
             )
         """
         return self._obj.no_wall_between(
-            from_pos, to_pos, [ls._obj for ls in boundary]
+            from_pos, to_pos, [ls._obj for ls in boundaries]
         )
 
     def line_segments_in_grid_cell_distance(

--- a/python_modules/jupedsim/jupedsim/environment_query.py
+++ b/python_modules/jupedsim/jupedsim/environment_query.py
@@ -63,6 +63,7 @@ class EnvironmentQuery:
         self,
         from_pos: tuple[float, float],
         to_pos: tuple[float, float],
+        boundary: list[LineSegment],
     ) -> bool:
         """Return ``True`` when the straight line from *from_pos* to *to_pos*
         is not intersected by any geometry boundary (i.e. no wall blocks it).
@@ -70,18 +71,23 @@ class EnvironmentQuery:
         Args:
             from_pos: Observer position as ``(x, y)`` in metres.
             to_pos: Target position as ``(x, y)`` in metres.
+            boundary: pre-fetched list of wall segments from
+                :meth:`line_segments_in_range`.
 
         Returns:
             ``True`` when line-of-sight is unobstructed.
 
-        Example::
+        Example — pre-fetch once, reuse for every neighbor::
 
+            walls = env_query.line_segments_in_range(ped.position, cutoff)
             neighbors = env_query.other_agents_in_range(
-                ped, 5.0,
-                lambda n: env_query.no_wall_between(ped.position, n.position)
+                ped, cutoff,
+                lambda n: env_query.no_wall_between(ped.position, n.position, walls)
             )
         """
-        return self._obj.no_wall_between(from_pos, to_pos)
+        return self._obj.no_wall_between(
+            from_pos, to_pos, [ls._obj for ls in boundary]
+        )
 
     def line_segments_in_grid_cell_distance(
         self,

--- a/python_modules/jupedsim/tests/test_environment_query.py
+++ b/python_modules/jupedsim/tests/test_environment_query.py
@@ -171,7 +171,11 @@ def test_no_wall_between_filters_occluded_agents():
                         ped,
                         20.0,
                         lambda n: env_query.no_wall_between(
-                            ped.position, n.position
+                            ped.position,
+                            n.position,
+                            env_query.line_segments_in_range(
+                                ped.position, 20.0
+                            ),
                         ),
                     )
                 ]
@@ -210,7 +214,11 @@ def test_no_wall_between_agent_above_wall_is_seen():
                         ped,
                         20.0,
                         lambda n: env_query.no_wall_between(
-                            ped.position, n.position
+                            ped.position,
+                            n.position,
+                            env_query.line_segments_in_range(
+                                ped.position, 20.0
+                            ),
                         ),
                     )
                 ]
@@ -246,7 +254,11 @@ def test_composed_no_wall_between_and_group_filter():
                         20.0,
                         lambda neighbor: (
                             env_query.no_wall_between(
-                                ped.position, neighbor.position
+                                ped.position,
+                                neighbor.position,
+                                env_query.line_segments_in_range(
+                                    ped.position, 20.0
+                                ),
                             )
                             and neighbor.model.group == 1
                         ),

--- a/python_modules/jupedsim/tests/test_environment_query.py
+++ b/python_modules/jupedsim/tests/test_environment_query.py
@@ -165,6 +165,7 @@ def test_no_wall_between_filters_occluded_agents():
         def compute_next_state(self, dt, ped, env_query):
             px, py = ped.position
             if abs(px - 5.0) < 1e-4 and abs(py - 10.0) < 1e-4:
+                walls = env_query.line_segments_in_range(ped.position, 20.0)
                 self.neighbor_positions = [
                     tuple(n.position)
                     for n in env_query.other_agents_in_range(
@@ -173,9 +174,7 @@ def test_no_wall_between_filters_occluded_agents():
                         lambda n: env_query.no_wall_between(
                             ped.position,
                             n.position,
-                            env_query.line_segments_in_range(
-                                ped.position, 20.0
-                            ),
+                            walls,
                         ),
                     )
                 ]
@@ -208,6 +207,7 @@ def test_no_wall_between_agent_above_wall_is_seen():
         def compute_next_state(self, _dt, ped, env_query):
             px, py = ped.position
             if abs(px - 5.0) < 1e-4 and abs(py - 18.0) < 1e-4:
+                walls = env_query.line_segments_in_range(ped.position, 20.0)
                 self.neighbor_positions = [
                     tuple(n.position)
                     for n in env_query.other_agents_in_range(
@@ -216,9 +216,7 @@ def test_no_wall_between_agent_above_wall_is_seen():
                         lambda n: env_query.no_wall_between(
                             ped.position,
                             n.position,
-                            env_query.line_segments_in_range(
-                                ped.position, 20.0
-                            ),
+                            walls,
                         ),
                     )
                 ]
@@ -247,6 +245,7 @@ def test_composed_no_wall_between_and_group_filter():
         def compute_next_state(self, _dt, ped, env_query):
             px, py = ped.position
             if abs(px - 5.0) < 1e-4 and abs(py - 10.0) < 1e-4:
+                walls = env_query.line_segments_in_range(ped.position, 20.0)
                 self.neighbor_positions = [
                     tuple(n.position)
                     for n in env_query.other_agents_in_range(
@@ -256,9 +255,7 @@ def test_composed_no_wall_between_and_group_filter():
                             env_query.no_wall_between(
                                 ped.position,
                                 neighbor.position,
-                                env_query.line_segments_in_range(
-                                    ped.position, 20.0
-                                ),
+                                walls,
                             )
                             and neighbor.model.group == 1
                         ),


### PR DESCRIPTION
In #1627, I introduced the new filter to filter out agents occluded by walls.
However, the walls where looked up every neighbor leading to a big performance penalty.

In this PR I introduce a caching behavior, that only recomputes the walls if the from location is changing.
This restored the previous computational performance.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1639/
<!-- PREVIEW-URL-END -->