### PR TITLE
Make CustomModel::State constructor explicit.

### DIFF
--- a/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
+++ b/libsimulator/src/OperationalModels/AnticipationVelocityModel/AnticipationVelocityModel.cpp
@@ -151,7 +151,7 @@ void AnticipationVelocityModel::CheckModelConstraint(
     constexpr double reactionTimeMax = 1.0;
     validateConstraint(reactionTime, reactionTimeMin, reactionTimeMax, "reactionTime", true);
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(agent.model, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighbor_model = std::get<State>(neighbor.model);
         const auto contanctdDist = r + neighbor_model.radius;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModel/CollisionFreeSpeedModel.cpp
@@ -104,7 +104,7 @@ void CollisionFreeSpeedModel::CheckModelConstraint(
     constexpr double timeGapMax = 10.;
     validateConstraint(timeGap, timeGapMin, timeGapMax, "timeGap");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(agent.model, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighbor_model = std::get<State>(neighbor.model);
         const auto contanctdDist = r + neighbor_model.radius;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV2/CollisionFreeSpeedModelV2.cpp
@@ -92,7 +92,7 @@ void CollisionFreeSpeedModelV2::CheckModelConstraint(
     constexpr double timeGapMax = 10.;
     validateConstraint(timeGap, timeGapMin, timeGapMax, "timeGap");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(agent.model, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighbor_model = std::get<State>(neighbor.model);
         const auto contanctdDist = r + neighbor_model.radius;

--- a/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
+++ b/libsimulator/src/OperationalModels/CollisionFreeSpeedModelV3/CollisionFreeSpeedModelV3.cpp
@@ -169,7 +169,7 @@ void CollisionFreeSpeedModelV3::CheckModelConstraint(
     validateConstraint(model.thetaMaxUpperBound, 0.0, std::acos(-1.0), "thetaMaxUpperBound");
     validateConstraint(model.agentBuffer, 0.0, 100.0, "agentBuffer");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(agent.model, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighbor_model = std::get<State>(neighbor.model);
         const auto contactDist = model.radius + neighbor_model.radius;

--- a/libsimulator/src/OperationalModels/CustomModel/CustomModel.hpp
+++ b/libsimulator/src/OperationalModels/CustomModel/CustomModel.hpp
@@ -80,7 +80,7 @@ public:
     public:
         template <typename T>
             requires(!std::is_same_v<std::decay_t<T>, State>)
-        State(T&& value) : value(std::forward<T>(value)), format(makeFormatFn<T>())
+        explicit State(T&& value) : value(std::forward<T>(value)), format(makeFormatFn<T>())
         {
             using Stored = std::decay_t<T>;
             static_assert(

--- a/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
+++ b/libsimulator/src/OperationalModels/GeneralizedCentrifugalForceModel/GeneralizedCentrifugalForceModel.cpp
@@ -128,7 +128,7 @@ void GeneralizedCentrifugalForceModel::CheckModelConstraint(
     constexpr double BMaxMax = 2.;
     validateConstraint(BMax, BMaxMin, BMaxMax, "BMax");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(agent.model, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighborModel = std::get<State>(neighbor.model);
         const auto contanctDist = AgentToAgentSpacing(agent, neighbor);

--- a/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
+++ b/libsimulator/src/OperationalModels/SocialForceModel/SocialForceModel.cpp
@@ -90,7 +90,7 @@ void SocialForceModel::CheckModelConstraint(
     const auto radius = model.radius;
     throwIfNegative(radius, "radius");
 
-    const auto neighbors = envQuery.OtherAgentsInRange(agent.position(), 2.0);
+    const auto neighbors = envQuery.OtherAgentsInRange(agent.model, 2.0);
     for(const auto& neighbor : neighbors) {
         const auto& neighborPosition = std::get<State>(neighbor.model).position;
         const auto distance = (model.position - neighborPosition).Norm();

--- a/libsimulator/test/TestCustomModel.cpp
+++ b/libsimulator/test/TestCustomModel.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 namespace
 {
@@ -68,6 +69,17 @@ TEST(CustomModel, TypeIsCustomModel)
 {
     const MinimalCustomModel model{};
     ASSERT_EQ(model.Type(), OperationalModelType::CUSTOM_MODEL);
+}
+
+TEST(CustomModelState, DoesNotSwallowArbitraryTypesImplicitly)
+{
+    // Ensure only explicit construction of CustomModelState and no implicit conversion
+    // from any type.
+    EXPECT_FALSE((std::is_convertible_v<Point, CustomModel::State>) );
+    EXPECT_FALSE((std::is_convertible_v<Point, GenericAgent::ModelState>) );
+    EXPECT_FALSE((std::is_convertible_v<GenericAgent, GenericAgent::ModelState>) );
+
+    EXPECT_TRUE((std::is_constructible_v<CustomModel::State, int>) );
 }
 
 TEST(CustomModelState, StoresAndUpdatesTypedPayload)

--- a/libsimulator/test/TestEnvironmentQuery.cpp
+++ b/libsimulator/test/TestEnvironmentQuery.cpp
@@ -63,7 +63,7 @@ TEST(EnvironmentQuery, AgentsInRangeExcludesSelf)
     const auto geo = OpenGeometry();
     const auto q = env.query(geo);
 
-    const auto result = q.OtherAgentsInRange(env.agents[0], 100.0);
+    const auto result = q.OtherAgentsInRange(env.agents[0].model, 100.0);
     EXPECT_TRUE(result.empty());
 }
 
@@ -77,7 +77,7 @@ TEST(EnvironmentQuery, AgentsInRangeNoFilterReturnsAllInRadius)
     const auto geo = OpenGeometry();
     const auto q = env.query(geo);
 
-    const auto result = q.OtherAgentsInRange(env.agents[0], 5.0);
+    const auto result = q.OtherAgentsInRange(env.agents[0].model, 5.0);
     EXPECT_EQ(result.size(), 3u);
 }
 
@@ -91,7 +91,7 @@ TEST(EnvironmentQuery, AgentsInRangeCustomFilterRejectsAll)
     const auto q = env.query(geo);
 
     const auto result =
-        q.OtherAgentsInRange(env.agents[0], 5.0, [](const Point&) { return false; });
+        q.OtherAgentsInRange(env.agents[0].model, 5.0, [](const Point&) { return false; });
     EXPECT_TRUE(result.empty());
 }
 
@@ -106,7 +106,7 @@ TEST(EnvironmentQuery, AgentsInRangeCustomFilterSelectsSubset)
     const auto q = env.query(geo);
 
     const auto result =
-        q.OtherAgentsInRange(env.agents[0], 5.0, [](const Point& to) { return to.x >= 0.0; });
+        q.OtherAgentsInRange(env.agents[0].model, 5.0, [](const Point& to) { return to.x >= 0.0; });
 
     ASSERT_EQ(result.size(), 2u);
     for(const auto& neighbor : result) {
@@ -125,7 +125,7 @@ TEST(EnvironmentQuery, NoGeometryBetweenFiltersOccludedAgents)
 
     const auto from = env.agents[0].position();
     const auto boundary = q.LineSegmentsInRange(from, 5.0);
-    const auto result = q.OtherAgentsInRange(env.agents[0], 5.0, [&](const Point& to) {
+    const auto result = q.OtherAgentsInRange(env.agents[0].model, 5.0, [&](const Point& to) {
         return q.NoGeometryBetween(from, to, boundary);
     });
 
@@ -143,12 +143,27 @@ TEST(EnvironmentQuery, AgentsInRangeCustomFilterReceivesNoSelf)
     const auto q = env.query(geo);
 
     const auto selfPos = env.agents[0].position();
-    q.OtherAgentsInRange(env.agents[0], 5.0, [&](const Point& to) {
+    q.OtherAgentsInRange(env.agents[0].model, 5.0, [&](const Point& to) {
         if(to == selfPos) {
             ADD_FAILURE() << "filter was called with the querying agent's own position";
         }
         return true;
     });
+}
+
+TEST(EnvironmentQuery, AgentsInRangeCentresOnTheQueryingAgentNotTheOrigin)
+{
+    Environment env{};
+    env.add_agent({50, 30}); // querying agent, deliberately away from the origin
+    env.add_agent({51, 30}); // its actual neighbor
+    env.add_agent({0.5, 0}); // decoy next to the origin
+    const auto geo = OpenGeometry();
+    const auto q = env.query(geo);
+
+    const auto result = q.OtherAgentsInRange(env.agents[0].model, 2.0);
+
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(std::get<State>(result[0].model).position, Point(51, 30));
 }
 
 TEST(EnvironmentQuery, AgentsInRangeOutOfRadiusNotReturned)
@@ -159,6 +174,7 @@ TEST(EnvironmentQuery, AgentsInRangeOutOfRadiusNotReturned)
     const auto geo = OpenGeometry();
     const auto q = env.query(geo);
 
-    const auto result = q.OtherAgentsInRange(env.agents[0], 1.0, [](const Point&) { return true; });
+    const auto result =
+        q.OtherAgentsInRange(env.agents[0].model, 1.0, [](const Point&) { return true; });
     EXPECT_TRUE(result.empty());
 }


### PR DESCRIPTION
- This prevents implicit conversion to CustomModel::State from any type.
- Fix corresponding issues in CheckModelConstraint of the operational models passing "position" instead of "state" which greedily converts to CustomModel::State. This caused models to check for neighbors around the origin instead of the real agent's position.
- Add corresponding tests to prevent this from happening again.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1640/
<!-- PREVIEW-URL-END -->