### PR TITLE
Default random seed for AVM

### DIFF
--- a/notebooks/model-comparison.ipynb
+++ b/notebooks/model-comparison.ipynb
@@ -1548,7 +1548,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv (3.14.4)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1562,7 +1562,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/model-comparison.ipynb
+++ b/notebooks/model-comparison.ipynb
@@ -338,7 +338,7 @@
     "model = \"AVM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
-    "    jps.AnticipationVelocityModel(rng_seed=42),\n",
+    "    jps.AnticipationVelocityModel(),\n",
     "    jps.AnticipationVelocityModelState,\n",
     "    geometry,\n",
     "    goals,\n",
@@ -606,7 +606,7 @@
     "model = \"AVM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
-    "    jps.AnticipationVelocityModel(rng_seed=42),\n",
+    "    jps.AnticipationVelocityModel(),\n",
     "    jps.AnticipationVelocityModelState,\n",
     "    geometry,\n",
     "    goals,\n",
@@ -851,7 +851,7 @@
     "model = \"AVM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
-    "    jps.AnticipationVelocityModel(rng_seed=42),\n",
+    "    jps.AnticipationVelocityModel(),\n",
     "    jps.AnticipationVelocityModelState,\n",
     "    geometry,\n",
     "    goals,\n",
@@ -1113,7 +1113,7 @@
     "model = \"AVM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
-    "    jps.AnticipationVelocityModel(rng_seed=42),\n",
+    "    jps.AnticipationVelocityModel(),\n",
     "    jps.AnticipationVelocityModelState,\n",
     "    geometry,\n",
     "    goals,\n",
@@ -1388,7 +1388,7 @@
     "model = \"AVM\"\n",
     "trajectory_file = f\"{model}.sqlite\"\n",
     "simulation = initialize_simulation(\n",
-    "    jps.AnticipationVelocityModel(rng_seed=42),\n",
+    "    jps.AnticipationVelocityModel(),\n",
     "    jps.AnticipationVelocityModelState,\n",
     "    geometry,\n",
     "    goals,\n",
@@ -1548,7 +1548,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv (3.14.4)",
    "language": "python",
    "name": "python3"
   },
@@ -1562,7 +1562,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,

--- a/python_bindings_jupedsim/anticipation_velocity_model.cpp
+++ b/python_bindings_jupedsim/anticipation_velocity_model.cpp
@@ -19,7 +19,7 @@ void init_anticipation_velocity_model(py::module_& m)
             py::init<double, uint64_t>(),
             py::kw_only(),
             py::arg("pushout_strength") = 0.3,
-            py::arg("rng_seed"));
+            py::arg("rng_seed") = 42);
     const AnticipationVelocityModel::State d{};
     py::class_<AnticipationVelocityModel::State>(m, "AnticipationVelocityModelState")
         .def(

--- a/systemtest/run_scenarios.py
+++ b/systemtest/run_scenarios.py
@@ -74,7 +74,7 @@ def scenarios():
     )
     yield (
         "AnticipationVelocityModel",
-        jps.AnticipationVelocityModel(rng_seed=1234),
+        jps.AnticipationVelocityModel(),
         lambda pos: jps.AnticipationVelocityModelState(position=pos),
     )
     yield (


### PR DESCRIPTION
Small PR, about adding a default value for the AVM random seed (again). This must have been dropped during refactoring all other models with random generators also have default values for the seed, this looks like a refactoring "bug" to me.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1641/
<!-- PREVIEW-URL-END -->