### PR TITLE
Introduce state mapping between current state and neighbor states

### DIFF
--- a/libsimulator/src/AgentView.hpp
+++ b/libsimulator/src/AgentView.hpp
@@ -37,14 +37,29 @@ inline bool intersects(const LineSegment& los, const WallView& wall)
 {
     return intersects(los, wall.segment);
 }
+/// Substitutes the model state neighbors are seen with.
+///
+/// A model that delegates a step to another model hands over a view of the world, but the
+/// delegate expects neighbors to carry its own state type. An implementation maps each
+/// neighbor's stored state to one the delegate understands and owns the mapped states for as
+/// long as it lives.
+class NeighborStates
+{
+public:
+    virtual ~NeighborStates() = default;
+    virtual const OperationalModelState& MapToCurrentState(const GenericAgent& agent) const = 0;
+};
 
 /// What an agent perceives of its surroundings, expressed relative to where it
 /// stands. Agents do not know absolute positions as they do not need to.
 class AgentView
 {
 public:
-    AgentView(const EnvironmentQuery& world, const GenericAgent& agent)
-        : _world(world), _agent(agent)
+    AgentView(
+        const EnvironmentQuery& world,
+        const GenericAgent& agent,
+        const NeighborStates* neighborStates = nullptr)
+        : _world(world), _agent(agent), _neighborStates(neighborStates)
     {
     }
 
@@ -61,13 +76,19 @@ public:
             if(candidate.id == _agent.id) {
                 return;
             }
-            const NeighborView neighbor{candidate.Position() - _agent.Position(), &candidate.state};
+            const NeighborView neighbor{
+                candidate.Position() - _agent.Position(),
+                _neighborStates ? &_neighborStates->MapToCurrentState(candidate) :
+                                  &candidate.state};
             if(filter(neighbor)) {
                 neighbors.push_back(neighbor);
             }
         });
         return neighbors;
     }
+
+    /// Whether neighbors are seen through a substituted state rather than their own.
+    bool HasNeighborMapping() const { return _neighborStates != nullptr; }
 
     /// Whether the straight line to a point at 'RelativePosition' is free of geometry.
     /// 'boundaries' must be in the same relative coordinate frame (agent at origin),
@@ -120,15 +141,28 @@ public:
 protected:
     const EnvironmentQuery& _world;
     const GenericAgent& _agent;
+    /// Null in the common case, where neighbors are seen with their own state.
+    const NeighborStates* _neighborStates;
 };
 
 /// An AgentView plus what only holds for one step (dT + next target).
 class AgentStep : public AgentView
 {
 public:
-    AgentStep(const EnvironmentQuery& world, const GenericAgent& agent, double dt)
-        : AgentView(world, agent), _dt(dt)
+    AgentStep(
+        const EnvironmentQuery& world,
+        const GenericAgent& agent,
+        double dt,
+        const NeighborStates* neighborStates = nullptr)
+        : AgentView(world, agent, neighborStates), _dt(dt)
     {
+    }
+
+    /// The same step, but with neighbors seen through 'states'. 'states' has to outlive the
+    /// returned step.
+    AgentStep WithNeighborStateMapping(const NeighborStates& states) const
+    {
+        return AgentStep{_world, _agent, _dt, &states};
     }
 
     double dt() const { return _dt; }

--- a/libsimulator/src/AgentView.hpp
+++ b/libsimulator/src/AgentView.hpp
@@ -43,11 +43,12 @@ inline bool intersects(const LineSegment& los, const WallView& wall)
 /// delegate expects neighbors to carry its own state type. An implementation maps each
 /// neighbor's stored state to one the delegate understands and owns the mapped states for as
 /// long as it lives.
-class NeighborStates
+class NeighborStateMapper
 {
 public:
-    virtual ~NeighborStates() = default;
-    virtual const OperationalModelState& MapToCurrentState(const GenericAgent& agent) const = 0;
+    virtual ~NeighborStateMapper() = default;
+    virtual const OperationalModelState&
+    MapToCurrentState(const OperationalModelState& agent) const = 0;
 };
 
 /// What an agent perceives of its surroundings, expressed relative to where it
@@ -58,8 +59,8 @@ public:
     AgentView(
         const EnvironmentQuery& world,
         const GenericAgent& agent,
-        const NeighborStates* neighborStates = nullptr)
-        : _world(world), _agent(agent), _neighborStates(neighborStates)
+        const NeighborStateMapper* neighborStateMapper = nullptr)
+        : _world(world), _agent(agent), _neighborStateMapper(neighborStateMapper)
     {
     }
 
@@ -78,8 +79,8 @@ public:
             }
             const NeighborView neighbor{
                 candidate.Position() - _agent.Position(),
-                _neighborStates ? &_neighborStates->MapToCurrentState(candidate) :
-                                  &candidate.state};
+                _neighborStateMapper ? &_neighborStateMapper->MapToCurrentState(candidate.state) :
+                                       &candidate.state};
             if(filter(neighbor)) {
                 neighbors.push_back(neighbor);
             }
@@ -88,7 +89,7 @@ public:
     }
 
     /// Whether neighbors are seen through a substituted state rather than their own.
-    bool HasNeighborMapping() const { return _neighborStates != nullptr; }
+    bool HasNeighborMapping() const { return _neighborStateMapper != nullptr; }
 
     /// Whether the straight line to a point at 'RelativePosition' is free of geometry.
     /// 'boundaries' must be in the same relative coordinate frame (agent at origin),
@@ -138,11 +139,19 @@ public:
         return AsSeenFromAgent(_world.LineSegmentsInRange(_agent.Position(), distance));
     }
 
+    /// The same view, but with neighbors seen through 'states'. 'states' has to outlive the
+    /// returned view. This is a virtual function to allow overriding in AgentStep, which has an
+    /// additional member (dt) that needs to be passed to the returned AgentStep.
+    AgentView WithNeighborStateMapping(const NeighborStateMapper& states) const
+    {
+        return AgentView{_world, _agent, &states};
+    }
+
 protected:
     const EnvironmentQuery& _world;
     const GenericAgent& _agent;
     /// Null in the common case, where neighbors are seen with their own state.
-    const NeighborStates* _neighborStates;
+    const NeighborStateMapper* _neighborStateMapper;
 };
 
 /// An AgentView plus what only holds for one step (dT + next target).
@@ -153,14 +162,14 @@ public:
         const EnvironmentQuery& world,
         const GenericAgent& agent,
         double dt,
-        const NeighborStates* neighborStates = nullptr)
-        : AgentView(world, agent, neighborStates), _dt(dt)
+        const NeighborStateMapper* neighborStateMapper = nullptr)
+        : AgentView(world, agent, neighborStateMapper), _dt(dt)
     {
     }
 
     /// The same step, but with neighbors seen through 'states'. 'states' has to outlive the
     /// returned step.
-    AgentStep WithNeighborStateMapping(const NeighborStates& states) const
+    AgentStep WithNeighborStateMapping(const NeighborStateMapper& states) const
     {
         return AgentStep{_world, _agent, _dt, &states};
     }

--- a/python_bindings_jupedsim/agent_view.cpp
+++ b/python_bindings_jupedsim/agent_view.cpp
@@ -9,23 +9,61 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <deque>
+#include <utility>
 #include <variant>
 
 namespace py = pybind11;
+
+namespace
+{
+py::object stateToPython(const OperationalModelState& state)
+{
+    const auto& variant = static_cast<const OperationalModelState&>(state);
+    if(const auto* custom = std::get_if<CustomModel::State>(&variant)) {
+        // Custom states are unwrapped so that the _CustomModelState transport type
+        // never reaches user code.
+        return custom->Get<GilSafePyObject>().Get();
+    }
+    return py::cast(variant);
+}
+
+/// Maps neighbor states through a Python callable, e.g. to hand a built-in model neighbors of
+/// the state type it expects.
+class PythonNeighborStates : public NeighborStates
+{
+    py::object _repack;
+    /// Deque, not vector: MappedTo() hands out references that must survive later calls.
+    mutable std::deque<OperationalModelState> _states{};
+
+public:
+    explicit PythonNeighborStates(py::object repack) : _repack(std::move(repack)) {}
+
+    const OperationalModelState& MapToCurrentState(const GenericAgent& agent) const override
+    {
+        py::object repacked = _repack(stateToPython(agent.state));
+        try {
+            _states.emplace_back(repacked.cast<OperationalModelState>());
+        } catch(const py::cast_error&) {
+            // Anything that is not a built-in state is a custom state, exactly as when an
+            // agent is added. This is what a Python model delegating to another Python model
+            // returns.
+            _states.emplace_back(CustomModel::State{GilSafePyObject{std::move(repacked)}});
+        }
+        return _states.back();
+    }
+};
+} // namespace
 
 void init_agent_view(py::module_& m)
 {
     py::class_<NeighborView>(m, "NeighborView")
         .def_readonly("relative_position", &NeighborView::RelativePosition)
-        .def_property_readonly("state", [](const NeighborView& self) -> py::object {
-            const auto& state = *self.state;
-            if(const auto* custom = std::get_if<CustomModel::State>(&state)) {
-                // Custom states are unwrapped so that the _CustomModelState transport type
-                // never reaches user code.
-                return custom->Get<GilSafePyObject>().Get();
-            }
-            return py::cast(state);
-        });
+        .def_property_readonly(
+            "state", [](const NeighborView& self) { return stateToPython(*self.state); });
+
+    py::class_<PythonNeighborStates>(m, "_NeighborStates")
+        .def(py::init<py::object>(), py::arg("repack"));
 
     py::class_<WallView>(m, "WallView")
         .def_readonly("segment", &WallView::segment)
@@ -67,6 +105,14 @@ void init_agent_view(py::module_& m)
             "Walls within exact distance of the agent, as seen from it.");
 
     py::class_<AgentStep, AgentView>(m, "AgentStep")
+        .def(
+            "with_neighbor_state_mapping",
+            [](const AgentStep& self, const PythonNeighborStates& states) {
+                return self.WithNeighborStateMapping(states);
+            },
+            py::arg("neighbor_states"),
+            py::keep_alive<0, 2>(),
+            "The same step, but with every neighbor seen through the given mapping.")
         .def_property_readonly("dt", &AgentStep::dt)
         .def_property_readonly("to_next_target", &AgentStep::ToNextTarget);
 }

--- a/python_bindings_jupedsim/agent_view.cpp
+++ b/python_bindings_jupedsim/agent_view.cpp
@@ -30,18 +30,19 @@ py::object stateToPython(const OperationalModelState& state)
 
 /// Maps neighbor states through a Python callable, e.g. to hand a built-in model neighbors of
 /// the state type it expects.
-class PythonNeighborStates : public NeighborStates
+class PythonNeighborStateMapper : public NeighborStateMapper
 {
     py::object _repack;
     /// Deque, not vector: MappedTo() hands out references that must survive later calls.
     mutable std::deque<OperationalModelState> _states{};
 
 public:
-    explicit PythonNeighborStates(py::object repack) : _repack(std::move(repack)) {}
+    explicit PythonNeighborStateMapper(py::object repack) : _repack(std::move(repack)) {}
 
-    const OperationalModelState& MapToCurrentState(const GenericAgent& agent) const override
+    const OperationalModelState&
+    MapToCurrentState(const OperationalModelState& state) const override
     {
-        py::object repacked = _repack(stateToPython(agent.state));
+        py::object repacked = _repack(stateToPython(state));
         try {
             _states.emplace_back(repacked.cast<OperationalModelState>());
         } catch(const py::cast_error&) {
@@ -62,7 +63,7 @@ void init_agent_view(py::module_& m)
         .def_property_readonly(
             "state", [](const NeighborView& self) { return stateToPython(*self.state); });
 
-    py::class_<PythonNeighborStates>(m, "_NeighborStates")
+    py::class_<PythonNeighborStateMapper>(m, "_NeighborStateMapper")
         .def(py::init<py::object>(), py::arg("repack"));
 
     py::class_<WallView>(m, "WallView")
@@ -102,12 +103,20 @@ void init_agent_view(py::module_& m)
                 return intoVec(self.WallsInRange(distance));
             },
             py::arg("distance"),
-            "Walls within exact distance of the agent, as seen from it.");
+            "Walls within exact distance of the agent, as seen from it.")
+        .def(
+            "with_neighbor_state_mapping",
+            [](const AgentView& self, const PythonNeighborStateMapper& states) {
+                return self.WithNeighborStateMapping(states);
+            },
+            py::arg("neighbor_states"),
+            py::keep_alive<0, 2>(),
+            "The same view, but with every neighbor seen through the given mapping.");
 
     py::class_<AgentStep, AgentView>(m, "AgentStep")
         .def(
             "with_neighbor_state_mapping",
-            [](const AgentStep& self, const PythonNeighborStates& states) {
+            [](const AgentStep& self, const PythonNeighborStateMapper& states) {
                 return self.WithNeighborStateMapping(states);
             },
             py::arg("neighbor_states"),

--- a/python_bindings_jupedsim/python_model.cpp
+++ b/python_bindings_jupedsim/python_model.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <variant>
 
 namespace py = pybind11;
 
@@ -163,9 +164,58 @@ void PythonModel::CheckModelConstraint(const GenericAgent& agent, const AgentVie
     _model.attr("_check_model_constraint")(pythonState, pythonView);
 }
 
+/// The Python surface wraps the native view in jupedsim.agent_view.AgentStep. A model that
+/// delegates hands on the step it was given, so accept either the wrapper or the native object.
+static const AgentStep& asAgentStep(const py::object& step)
+{
+    const py::object native = py::hasattr(step, "_obj") ? step.attr("_obj") : step;
+    try {
+        return *native.cast<const AgentStep*>();
+    } catch(const py::cast_error&) {
+        throw SimulationError(
+            "compute_next_state() expects the step it was called with, got {}", Describe(step));
+    }
+}
+
 void init_python_model(py::module_& m)
 {
-    py::class_<OperationalModel, py::smart_holder>(m, "OperationalModel");
+    py::class_<OperationalModel, py::smart_holder>(m, "OperationalModel")
+        .def(
+            "compute_next_state",
+            [](const OperationalModel& self, OperationalModelState state, py::object step) {
+                const AgentStep& agentStep = asAgentStep(step);
+                const OperationalModelState current{std::move(state)};
+                if(ModelTypeOf(current) != self.Type()) {
+                    throw SimulationError(
+                        "{} cannot compute a state of type '{}'",
+                        ToString(self.Type()),
+                        ToString(ModelTypeOf(current)));
+                }
+                OperationalModelState next{current};
+
+                Point movement{};
+                try {
+                    movement = self.ComputeNextState(current, next, agentStep);
+                } catch(const std::bad_variant_access&) {
+                    // The state handed in is of the right type, so it was a neighbor's.
+                    throw SimulationError(
+                        agentStep.HasNeighborMapping() ?
+                            "{} encountered a neighbor it cannot read. The mapping passed to "
+                            "with_neighbor_states() has to return '{}' states." :
+                            "{} encountered a neighbor it cannot read. Map neighbors to '{}' "
+                            "states with AgentStep.with_neighbor_states() before delegating.",
+                        ToString(self.Type()),
+                        ToString(self.Type()));
+                }
+
+                return std::make_tuple(
+                    static_cast<const OperationalModelState&>(next),
+                    std::make_tuple(movement.x, movement.y));
+            },
+            py::arg("state"),
+            py::arg("step"),
+            "Run this model for one step on 'state', as perceived through 'step'. Returns "
+            "(next_state, movement). The agent's stored state is not touched.");
 
     py::class_<CustomModel::State>(m, "_CustomModelState")
         .def(py::init([](py::object model) {

--- a/python_modules/jupedsim/jupedsim/agent_view.py
+++ b/python_modules/jupedsim/jupedsim/agent_view.py
@@ -185,6 +185,33 @@ class AgentView:
         """
         return [WallView(w) for w in self._obj.walls_in_range(distance)]
 
+    def with_neighbor_state_mapping(
+        self, repack: Callable[[Any], Any]
+    ) -> "AgentStep":
+        """Return this view with every neighbor seen through *repack*.
+
+        Use this to delegate a view to a built-in model whose
+        ``check_model_constraint`` expects neighbors to carry its own state type::
+
+            def check_model_constraint(self, state, view):
+                cfsm_view = view.with_neighbor_states(self.as_cfsm_state)
+                return self._cfsm.check_model_constraint(state.sub, cfsm_view)
+
+        This view is not modified, so the model keeps seeing its own states.
+
+        Args:
+            repack: Callable ``(neighbor_state) -> state``, called once per
+                neighbor per query. It has to return a built-in model state.
+
+        Returns:
+            A new :class:`AgentView`. Only valid during the current callback.
+        """
+        return AgentView(
+            self._obj.with_neighbor_state_mapping(
+                py_jps._NeighborStateMapper(repack)
+            )
+        )
+
 
 class AgentStep(AgentView):
     """An :class:`AgentView` plus what only holds for one step.
@@ -227,6 +254,6 @@ class AgentStep(AgentView):
         """
         return AgentStep(
             self._obj.with_neighbor_state_mapping(
-                py_jps._NeighborStates(repack)
+                py_jps._NeighborStateMapper(repack)
             )
         )

--- a/python_modules/jupedsim/jupedsim/agent_view.py
+++ b/python_modules/jupedsim/jupedsim/agent_view.py
@@ -202,3 +202,31 @@ class AgentStep(AgentView):
     def to_next_target(self) -> tuple[float, float]:
         """Vector from the agent to its next target."""
         return self._obj.to_next_target
+
+    def with_neighbor_state_mapping(
+        self, repack: Callable[[Any], Any]
+    ) -> "AgentStep":
+        """Return this step with every neighbor seen through *repack*.
+
+        Use this to delegate a step to a built-in model whose
+        ``compute_next_state`` expects neighbors to carry its own state type::
+
+            def compute_next_state(self, state, step):
+                cfsm_step = step.with_neighbor_states(self.as_cfsm_state)
+                sub, movement = self._cfsm.compute_next_state(state.sub, cfsm_step)
+                return replace(state, sub=sub), movement
+
+        This step is not modified, so the model keeps seeing its own states.
+
+        Args:
+            repack: Callable ``(neighbor_state) -> state``, called once per
+                neighbor per query. It has to return a built-in model state.
+
+        Returns:
+            A new :class:`AgentStep`. Only valid during the current callback.
+        """
+        return AgentStep(
+            self._obj.with_neighbor_state_mapping(
+                py_jps._NeighborStates(repack)
+            )
+        )

--- a/python_modules/jupedsim/tests/test_model_delegation.py
+++ b/python_modules/jupedsim/tests/test_model_delegation.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""A Python model delegating one step to a built-in C++ model.
+
+Step 1 of the multi-model prototype: only the call surface is exercised, with a
+single agent so that no neighbor state is ever looked up.
+"""
+
+from dataclasses import dataclass, replace
+
+import jupedsim as jps
+import pytest
+import shapely
+
+
+@dataclass(kw_only=True, frozen=True)
+class _Wrapped:
+    """Custom state that carries a built-in model state as its payload."""
+
+    sub: object
+
+
+class _DelegatingModel(jps.CustomOperationalModel):
+    """Hands the whole step over to a built-in model and passes on its result.
+
+    With ``repack_neighbors``, neighbors are mapped to the state type the inner
+    model expects; without it, the inner model sees the stored custom states.
+    """
+
+    def __init__(self, inner, *, repack_neighbors=False):
+        super().__init__()
+        self._inner = inner
+        self._repack_neighbors = repack_neighbors
+
+    def compute_next_state(self, state, step):
+        if self._repack_neighbors:
+            step = step.with_neighbor_state_mapping(
+                lambda neighbor: neighbor.sub
+            )
+        sub, movement = self._inner.compute_next_state(state.sub, step)
+        return replace(state, sub=sub), movement
+
+
+def _open_room():
+    return shapely.Polygon([(0, 0), (20, 0), (20, 20), (0, 20)])
+
+
+def _make_sim(model):
+    sim = jps.Simulation(model=model, geometry=_open_room(), dt=0.05)
+    exit_id = sim.add_exit_stage([(19, 9), (19, 11), (20, 11), (20, 9)])
+    journey_id = sim.add_journey(jps.JourneyDescription([exit_id]))
+    return sim, exit_id, journey_id
+
+
+def _run(sim, journey_id, stage_id, state, steps=40):
+    agent_id = sim.add_agent(
+        journey_id=journey_id,
+        stage_id=stage_id,
+        position=(1.0, 10.0),
+        state=state,
+    )
+    trajectory = [sim.agent(agent_id).position]
+    for _ in range(steps):
+        sim.iterate()
+        trajectory.append(sim.agent(agent_id).position)
+    return trajectory
+
+
+def test_delegated_model_walks_towards_the_exit():
+    sim, exit_id, journey_id = _make_sim(
+        _DelegatingModel(jps.CollisionFreeSpeedModelV3())
+    )
+    trajectory = _run(
+        sim,
+        journey_id,
+        exit_id,
+        _Wrapped(sub=jps.CollisionFreeSpeedModelV3State()),
+    )
+
+    assert trajectory[-1][0] > trajectory[0][0] + 1.0
+
+
+def test_delegation_matches_the_native_model_exactly():
+    """The delegated run must reproduce the built-in model step for step."""
+    native_sim, native_exit, native_journey = _make_sim(
+        jps.CollisionFreeSpeedModelV3()
+    )
+    native = _run(
+        native_sim,
+        native_journey,
+        native_exit,
+        jps.CollisionFreeSpeedModelV3State(),
+    )
+
+    delegating_sim, delegating_exit, delegating_journey = _make_sim(
+        _DelegatingModel(jps.CollisionFreeSpeedModelV3())
+    )
+    delegated = _run(
+        delegating_sim,
+        delegating_journey,
+        delegating_exit,
+        _Wrapped(sub=jps.CollisionFreeSpeedModelV3State()),
+    )
+
+    assert delegated == native
+
+
+def test_delegated_state_is_advanced():
+    """The sub-state returned by the built-in model is a new, updated object."""
+    initial = jps.CollisionFreeSpeedModelV3State()
+    sim, exit_id, journey_id = _make_sim(
+        _DelegatingModel(jps.CollisionFreeSpeedModelV3())
+    )
+    # Off the exit axis, so that the model has to turn and the change is visible.
+    agent_id = sim.add_agent(
+        journey_id=journey_id,
+        stage_id=exit_id,
+        position=(1.0, 3.0),
+        state=_Wrapped(sub=initial),
+    )
+    sim.iterate()
+
+    sub = sim.agent(agent_id).state.sub
+    assert sub is not initial
+    assert sub.orientation != initial.orientation
+
+
+def test_wrong_state_type_is_reported_with_both_names():
+    sim, exit_id, journey_id = _make_sim(
+        _DelegatingModel(jps.SocialForceModel(body_force=0.0, friction=0.0))
+    )
+    sim.add_agent(
+        journey_id=journey_id,
+        stage_id=exit_id,
+        position=(1.0, 10.0),
+        state=_Wrapped(sub=jps.CollisionFreeSpeedModelV3State()),
+    )
+
+    with pytest.raises(
+        jps.SimulationError, match="SocialForceModel.*CollisionFreeSpeedModelV3"
+    ):
+        sim.iterate()
+
+
+def _run_pair(sim, journey_id, stage_id, state_of, steps=40):
+    """Two agents on a collision course, so that neighbor states are read."""
+    left = sim.add_agent(
+        journey_id=journey_id,
+        stage_id=stage_id,
+        position=(1.0, 10.0),
+        state=state_of(),
+    )
+    ahead = sim.add_agent(
+        journey_id=journey_id,
+        stage_id=stage_id,
+        position=(2.2, 10.0),
+        state=state_of(),
+    )
+    trajectory = []
+    for _ in range(steps):
+        sim.iterate()
+        trajectory.append((sim.agent(left).position, sim.agent(ahead).position))
+    return trajectory
+
+
+def test_neighbors_are_unreadable_without_the_hook():
+    """The failure the hook exists for, and the message that points at it."""
+    sim, exit_id, journey_id = _make_sim(
+        _DelegatingModel(jps.CollisionFreeSpeedModelV3())
+    )
+    with pytest.raises(jps.SimulationError, match="with_neighbor_states"):
+        _run_pair(
+            sim,
+            journey_id,
+            exit_id,
+            lambda: _Wrapped(sub=jps.CollisionFreeSpeedModelV3State()),
+            steps=1,
+        )
+
+
+def test_repacked_neighbors_match_the_native_model_exactly():
+    """Two interacting agents, mapped 1:1 -- must reproduce the built-in model."""
+    native_sim, native_exit, native_journey = _make_sim(
+        jps.CollisionFreeSpeedModelV3()
+    )
+    native = _run_pair(
+        native_sim,
+        native_journey,
+        native_exit,
+        jps.CollisionFreeSpeedModelV3State,
+    )
+
+    sim, exit_id, journey_id = _make_sim(
+        _DelegatingModel(jps.CollisionFreeSpeedModelV3(), repack_neighbors=True)
+    )
+    delegated = _run_pair(
+        sim,
+        journey_id,
+        exit_id,
+        lambda: _Wrapped(sub=jps.CollisionFreeSpeedModelV3State()),
+    )
+
+    assert delegated == native
+
+
+def test_repacked_neighbors_are_actually_seen():
+    """A mapping that inflates neighbors must change the outcome."""
+
+    def _fat(_):
+        return jps.CollisionFreeSpeedModelV3State(radius=0.5)
+
+    sim, exit_id, journey_id = _make_sim(
+        _DelegatingModel(jps.CollisionFreeSpeedModelV3(), repack_neighbors=True)
+    )
+    lean = _run_pair(
+        sim,
+        journey_id,
+        exit_id,
+        lambda: _Wrapped(sub=jps.CollisionFreeSpeedModelV3State()),
+    )
+
+    class _FatNeighbors(_DelegatingModel):
+        def compute_next_state(self, state, step):
+            step = step.with_neighbor_state_mapping(_fat)
+            sub, movement = self._inner.compute_next_state(state.sub, step)
+            return replace(state, sub=sub), movement
+
+    fat_sim, fat_exit, fat_journey = _make_sim(
+        _FatNeighbors(jps.CollisionFreeSpeedModelV3())
+    )
+    fat = _run_pair(
+        fat_sim,
+        fat_journey,
+        fat_exit,
+        lambda: _Wrapped(sub=jps.CollisionFreeSpeedModelV3State()),
+    )
+
+    assert fat != lean
+
+
+def test_a_wrong_mapping_blames_the_mapping():
+    """With a mapping in place, the error must point at it, not at its absence."""
+
+    class _Broken(_DelegatingModel):
+        def compute_next_state(self, state, step):
+            step = step.with_neighbor_state_mapping(lambda _: "not a state")
+            sub, movement = self._inner.compute_next_state(state.sub, step)
+            return replace(state, sub=sub), movement
+
+    sim, exit_id, journey_id = _make_sim(
+        _Broken(jps.CollisionFreeSpeedModelV3())
+    )
+    with pytest.raises(
+        jps.SimulationError,
+        match="mapping passed to with_neighbor_states.. has to return",
+    ):
+        _run_pair(
+            sim,
+            journey_id,
+            exit_id,
+            lambda: _Wrapped(sub=jps.CollisionFreeSpeedModelV3State()),
+            steps=1,
+        )
+
+
+def test_step_argument_must_be_a_step():
+    model = jps.CollisionFreeSpeedModelV3()
+    with pytest.raises(jps.SimulationError, match="expects the step"):
+        model.compute_next_state(jps.CollisionFreeSpeedModelV3State(), 42)

--- a/python_modules/jupedsim_examples/tests/test_multi_model.py
+++ b/python_modules/jupedsim_examples/tests/test_multi_model.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Two operational models side by side in one simulation.
+
+The simulation runs a single model, a dispatcher, whose agents carry the state
+of the sub-model they belong to. Each sub-model is handed a step in which the
+neighbors carry the state type that sub-model expects.
+"""
+
+from dataclasses import dataclass, replace
+
+import jupedsim as jps
+import pytest
+import shapely
+from jupedsim_examples.models.pysocial_force import (
+    PythonSocialForceModel,
+    PythonSocialForceModelState,
+)
+
+
+@dataclass(kw_only=True, frozen=True)
+class MultiModelState:
+    """Per-agent state of the dispatcher: which sub-model, and its state."""
+
+    kind: str
+    sub: object
+
+
+class MultiModel(jps.CustomOperationalModel):
+    """Dispatches each agent to its sub-model.
+
+    A sub-model must never see a ``MultiModelState``, so every neighbor is
+    mapped to the state type the sub-model reads. The mappings are the
+    modelling decision this class makes: they say what an agent of one model
+    looks like to an agent of the other.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._social_force = PythonSocialForceModel()
+        self._collision_free = jps.CollisionFreeSpeedModelV3()
+
+    @staticmethod
+    def _as_social_force_state(neighbor):
+        """How a neighbor is seen by the social force model.
+
+        It reads ``radius`` and ``velocity``. CollisionFreeSpeedModelV3 has no
+        velocity -- it stores a heading only -- so the neighbor's speed has to
+        be reconstructed from its orientation and desired speed.
+        """
+        if neighbor.kind == "social_force":
+            return neighbor.sub
+        sub = neighbor.sub
+        return PythonSocialForceModelState(
+            velocity=(
+                sub.orientation[0] * sub.desired_speed,
+                sub.orientation[1] * sub.desired_speed,
+            ),
+            radius=sub.radius,
+        )
+
+    @staticmethod
+    def _as_collision_free_state(neighbor):
+        """How a neighbor is seen by the collision free speed model.
+
+        It reads ``radius`` of a neighbor and nothing else.
+        """
+        if neighbor.kind == "collision_free":
+            return neighbor.sub
+        return jps.CollisionFreeSpeedModelV3State(radius=neighbor.sub.radius)
+
+    def compute_next_state(self, state, step):
+        if state.kind == "social_force":
+            sub_step = step.with_neighbor_state_mapping(
+                self._as_social_force_state
+            )
+            sub, movement = self._social_force.compute_next_state(
+                state.sub, sub_step
+            )
+        else:
+            sub_step = step.with_neighbor_state_mapping(
+                self._as_collision_free_state
+            )
+            sub, movement = self._collision_free.compute_next_state(
+                state.sub, sub_step
+            )
+        return replace(state, sub=sub), movement
+
+
+def _corridor():
+    return shapely.Polygon([(0, 0), (30, 0), (30, 8), (0, 8)])
+
+
+def _make_sim(model):
+    sim = jps.Simulation(model=model, geometry=_corridor(), dt=0.01)
+    exit_id = sim.add_exit_stage([(29, 3), (29, 5), (30, 5), (30, 3)])
+    journey_id = sim.add_journey(jps.JourneyDescription([exit_id]))
+    return sim, exit_id, journey_id
+
+
+def _social_force_agent():
+    return MultiModelState(
+        kind="social_force",
+        sub=PythonSocialForceModelState(velocity=(0.0, 0.0)),
+    )
+
+
+def _collision_free_agent():
+    return MultiModelState(
+        kind="collision_free",
+        sub=jps.CollisionFreeSpeedModelV3State(),
+    )
+
+
+def _add(sim, journey_id, stage_id, position, state):
+    return sim.add_agent(
+        journey_id=journey_id,
+        stage_id=stage_id,
+        position=position,
+        state=state,
+    )
+
+
+def test_both_models_advance_in_one_simulation():
+    sim, exit_id, journey_id = _make_sim(MultiModel())
+    left = _add(sim, journey_id, exit_id, (2.0, 3.0), _social_force_agent())
+    right = _add(sim, journey_id, exit_id, (2.0, 5.0), _collision_free_agent())
+
+    start = (sim.agent(left).position, sim.agent(right).position)
+    for _ in range(200):
+        sim.iterate()
+    end = (sim.agent(left).position, sim.agent(right).position)
+
+    assert end[0][0] > start[0][0] + 0.5
+    assert end[1][0] > start[1][0] + 0.5
+
+
+def test_each_agent_keeps_its_own_state_type():
+    sim, exit_id, journey_id = _make_sim(MultiModel())
+    left = _add(sim, journey_id, exit_id, (2.0, 3.0), _social_force_agent())
+    right = _add(sim, journey_id, exit_id, (2.0, 5.0), _collision_free_agent())
+
+    for _ in range(10):
+        sim.iterate()
+
+    assert isinstance(sim.agent(left).state.sub, PythonSocialForceModelState)
+    assert isinstance(
+        sim.agent(right).state.sub, jps.CollisionFreeSpeedModelV3State
+    )
+
+
+def test_the_models_see_each_other():
+    """A collision free agent must react to a social force agent in its way."""
+    sim, exit_id, journey_id = _make_sim(MultiModel())
+    blocked = _add(
+        sim, journey_id, exit_id, (2.0, 4.0), _collision_free_agent()
+    )
+    _add(sim, journey_id, exit_id, (2.6, 4.0), _social_force_agent())
+    for _ in range(50):
+        sim.iterate()
+    with_neighbor = sim.agent(blocked).position
+
+    free_sim, free_exit, free_journey = _make_sim(MultiModel())
+    alone = _add(
+        free_sim, free_journey, free_exit, (2.0, 4.0), _collision_free_agent()
+    )
+    for _ in range(50):
+        free_sim.iterate()
+    without_neighbor = free_sim.agent(alone).position
+
+    assert with_neighbor != without_neighbor
+    assert with_neighbor[0] < without_neighbor[0]
+
+
+def test_an_unmapped_neighbor_is_reported():
+    """Forgetting the mapping must fail loudly, not silently misbehave."""
+
+    class _Forgetful(MultiModel):
+        def compute_next_state(self, state, step):
+            if state.kind == "social_force":
+                return super().compute_next_state(state, step)
+            sub, movement = self._collision_free.compute_next_state(
+                state.sub, step
+            )
+            return replace(state, sub=sub), movement
+
+    sim, exit_id, journey_id = _make_sim(_Forgetful())
+    _add(sim, journey_id, exit_id, (2.0, 4.0), _collision_free_agent())
+    _add(sim, journey_id, exit_id, (2.6, 4.0), _social_force_agent())
+
+    with pytest.raises(jps.SimulationError, match="with_neighbor_states"):
+        sim.iterate()


### PR DESCRIPTION
This pull request introduces a mechanism for Python models to delegate simulation steps to built-in C++ models while controlling how neighbor agent states are presented. This enables seamless model composition, where a Python model can "wrap" a built-in model and ensure neighbors are seen with the expected state type, solving a key challenge for multi-model simulations. The changes add C++ and Python APIs for neighbor state mapping, and some tests.

The most important changes are:

**Core C++ API and Implementation:**

* Introduced the `NeighborStates` interface and added support to `AgentView` and `AgentStep` for substituting how neighbor states are seen, enabling custom mapping of neighbor states for delegation scenarios. [[1]](diffhunk://#diff-41e72be8cecf5b79ccd2503bed775f033467bd4153637a3147a24a363c2ce424R40-R62) [[2]](diffhunk://#diff-41e72be8cecf5b79ccd2503bed775f033467bd4153637a3147a24a363c2ce424L64-R92) [[3]](diffhunk://#diff-41e72be8cecf5b79ccd2503bed775f033467bd4153637a3147a24a363c2ce424R144-R165)
* Implemented `PythonNeighborStates`, a C++ class that wraps a Python callable to perform neighbor state mapping, and exposed it to Python via bindings.

**Python Bindings and API:**

* Added the `AgentStep.with_neighbor_state_mapping()` method to the Python API, enabling Python models to create a view where neighbors are seen through a user-provided mapping function. [[1]](diffhunk://#diff-90aeaf927335584cc7ee6be6c13c3db8b50ccee3000ba2022599f8a2c49a919dR205-R232) [[2]](diffhunk://#diff-e9bef486962cef30987502b612b80a198898a5c9d1e3886afcec399bffda3d58R108-R115)
* Updated the C++/Python API for native models to accept either a wrapped or native `AgentStep` and to provide clear error messages when state types are mismatched or mappings are incorrect.

**Testing and Validation:**

* Added a test suite (`test_model_delegation.py`) that verifies delegation, neighbor state mapping, error handling, and behavioral equivalence between delegated and native models.


<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1642/
<!-- PREVIEW-URL-END -->