### PR TITLE
Revert change of using ccache if available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,19 +29,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 check_prefix_path()
 
 ################################################################################
-# Compiler cache
-################################################################################
-# Use ccache if available. This especially helps wrt. compiling
-# third-party/perfetto/perfetto.cc.
-if(PROJECT_IS_TOP_LEVEL AND NOT DEFINED CMAKE_CXX_COMPILER_LAUNCHER)
-    find_program(CCACHE_PROGRAM ccache)
-    if(CCACHE_PROGRAM)
-        set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
-    endif()
-endif()
-print_var(CMAKE_CXX_COMPILER_LAUNCHER)
-
-################################################################################
 # Optional features
 ################################################################################
 set(WERROR OFF CACHE BOOL "Build wth -Werror enabled. Not supported on Windows")


### PR DESCRIPTION
The developer is expected to set -DCMAKE_CXX_COMPILER_LAUNCHER=ccache instead.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1645/
<!-- PREVIEW-URL-END -->