### PR TITLE
Fix visualization context for macOS

### DIFF
--- a/python_modules/jupedsim_visualizer/jupedsim_visualizer/geometry_widget.py
+++ b/python_modules/jupedsim_visualizer/jupedsim_visualizer/geometry_widget.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import sys
+
 import jupedsim as jps
+import vtkmodules.qt
 import vtkmodules.vtkRenderingOpenGL2  # noqa: F401
 from jupedsim.internal.aabb import AABB
 from PySide6.QtCore import Signal
-from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 from vtkmodules.vtkInteractionStyle import vtkInteractorStyleUser
 from vtkmodules.vtkRenderingCore import vtkRenderer
 
@@ -11,6 +13,12 @@ from jupedsim_visualizer.config import Colors
 from jupedsim_visualizer.geometry import HoverInfo
 from jupedsim_visualizer.grid import Grid
 from jupedsim_visualizer.move_controller import MoveController
+
+# On macOS with Qt6/PySide6, QOpenGLWidget is required so Qt manages the OpenGL context;
+# QWidget (the default) does not expose a native handle that VTK can attach to there.
+if sys.platform == "darwin":
+    vtkmodules.qt.QVTKRWIBase = "QOpenGLWidget"
+from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor  # noqa: E402  # isort: skip
 
 
 class RenderWidget(QVTKRenderWindowInteractor):


### PR DESCRIPTION
This pull request updates the `geometry_widget.py` file to improve compatibility with macOS when using Qt6/PySide6 and VTK. The main change ensures that the OpenGL context is correctly managed on macOS by specifying the appropriate Qt widget base class for VTK.

**macOS and VTK/Qt6 compatibility:**

* Added a platform check for macOS (`sys.platform == "darwin"`) to set `vtkmodules.qt.QVTKRWIBase` to `"QOpenGLWidget"`, ensuring that Qt manages the OpenGL context properly, which is required for VTK integration with Qt6/PySide6 on macOS.

**Imports and initialization:**

* Added imports for `sys` and `vtkmodules.qt` to support the new platform-specific logic.
* Moved the import of `QVTKRenderWindowInteractor` after the platform check to ensure the correct widget base is set before importing.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1646/
<!-- PREVIEW-URL-END -->