### PR TITLE
Restore writer performance

### DIFF
--- a/python_modules/jupedsim/jupedsim/hdf5_serialization.py
+++ b/python_modules/jupedsim/jupedsim/hdf5_serialization.py
@@ -231,7 +231,7 @@ class Hdf5TrajectoryWriter(TrajectoryWriter):
             return
         frame = iteration // self._every_nth_frame
 
-        for agent in simulation.agents():
+        for agent in simulation._obj.agents():
             self._buffer.append(
                 (
                     frame,

--- a/python_modules/jupedsim/jupedsim/sqlite_serialization.py
+++ b/python_modules/jupedsim/jupedsim/sqlite_serialization.py
@@ -144,7 +144,7 @@ class SqliteTrajectoryWriter(TrajectoryWriter):
                     agent.position[0],
                     agent.position[1],
                 )
-                for agent in simulation.agents()
+                for agent in simulation._obj.agents()
             ]
             cur.executemany(
                 "INSERT INTO trajectory_data VALUES(?, ?, ?, ?)",


### PR DESCRIPTION
This pull request updates the way agent data is accessed during serialization in both the HDF5 and SQLite serialization modules. The main change is to use the internal `_obj.agents()` method instead of the public `agents()` method when iterating over agents in a simulation. The previous version came with a large performance hit as a repack of all in some cases well above 15k agents is needed.

**Serialization logic update:**

* Updated agent iteration to use `simulation._obj.agents()` instead of `simulation.agents()` in both `hdf5_serialization.py` and `sqlite_serialization.py`, ensuring consistency with internal data access patterns. [[1]](diffhunk://#diff-51bc8dc0074003f70273df6a3d8a4fdf36c5997b9e57bb28da1df4977ccb9786L234-R234) [[2]](diffhunk://#diff-58d013982c2687cec46e9e06f961e6b7b9d79aaab389864ce9ce050c16d5f8b2L147-R147)


<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1647/
<!-- PREVIEW-URL-END -->