### PR TITLE
Fetch citation information with zenodo-bibtex-exporter

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,3 +16,7 @@ plotly-express
 numpy
 pandas
 pedpy
+
+# Citation information is fetched from Zenodo at build time.
+# Pinned to a branch until the tool is released to PyPI.
+zenodo-bibtex-exporter @ git+https://github.com/schroedtert/zenodo-bibtex-exporter.git@create-zenodo-bibtex-exporter

--- a/docs/source/_scripts/generate_bibtex.py
+++ b/docs/source/_scripts/generate_bibtex.py
@@ -1,68 +1,60 @@
-import textwrap
-import time
-import warnings
+"""Fetch the citation information for this build from Zenodo.
 
-import requests
+The record is looked up by *concept id*, the identifier that stays the same
+across all releases, rather than by searching for the project name. A name
+search matches titles, descriptions and author names, so it can return an
+unrelated record, and it reads only one page of results. Zenodo caps that page
+at 25 records for anonymous requests, and JuPedSim has more published versions
+than that, so versions below the cap were no longer findable at all.
+
+Zenodo being briefly unreachable must not fail the documentation build, so this
+always returns a string: the record for the version being built, otherwise the
+most recent release, otherwise a comment pointing at the DOI.
+"""
+
+import logging
+
+from zenodo_bibtex_exporter import ZenodoBibtexError, get_bibtex
+
+logger = logging.getLogger(__name__)
+
+#: JuPedSim on Zenodo. This is the concept id, which never changes between releases.
+CONCEPT_ID = "1293771"
+
+CONCEPT_DOI_URL = f"https://doi.org/10.5281/zenodo.{CONCEPT_ID}"
 
 
-def _fetch_data_with_retries(
-    url, params=None, headers=None, max_retries=10, wait_time=2
-):
-    for attempt in range(max_retries):
-        try:
-            response = requests.get(url, params=params, headers=headers)
-            response.raise_for_status()
-            return response
-        except requests.RequestException as e:
-            warnings.warn(f"Attempt {attempt + 1} failed: {e}")
-            time.sleep(wait_time)
-    raise RuntimeError("All attempts to fetch data failed.")
+def get_latest_jupedsim_bibtex(installed_version: str) -> str:
+    """Return the BibTeX entry to publish with the documentation.
 
+    Args:
+        installed_version: Version being documented, as published on Zenodo,
+            for example ``v1.4.2``. Matched verbatim.
 
-def get_latest_jupedsim_bibtex(installed_version):
+    Returns:
+        A BibTeX entry, or a BibTeX comment explaining why there is none.
+    """
     try:
-        response = _fetch_data_with_retries(
-            "https://zenodo.org/api/records",
-            params={
-                "q": "JuPedSim",
-                "all_versions": True,
-                "sort": "mostrecent",
-                "communities": "fire-safety-engineering-and-evacuation",
-            },
+        entry = get_bibtex(CONCEPT_ID, version=installed_version)
+    except ZenodoBibtexError as error:
+        logger.warning("No Zenodo record for %s: %s", installed_version, error)
+    else:
+        logger.info("Using the Zenodo record for %s.", installed_version)
+        return entry
+
+    try:
+        entry = get_bibtex(CONCEPT_ID)
+    except ZenodoBibtexError as error:
+        logger.warning("No citation information available at all: %s", error)
+        return (
+            f"% Citation information could not be retrieved from Zenodo.\n"
+            f"% It is available at {CONCEPT_DOI_URL}\n"
         )
-        records = response.json()["hits"]["hits"]
-
-        if not records:
-            raise RuntimeError("No records found for JuPedSim.")
-
-        record_id = None
-        for record in records:
-            fetched_version = record["metadata"].get("version", "NO VERSION")
-
-            if fetched_version == installed_version:
-                record_id = record["id"]
-                break
-
-        if not record_id:
-            return textwrap.dedent(f"""\
-                No citation information available for this version: {installed_version}
-                Please check on Zenodo: https://doi.org/10.5281/zenodo.1293771
-                """)
-
-        headers = {"accept": "application/x-bibtex"}
-        response = _fetch_data_with_retries(
-            f"https://zenodo.org/api/records/{record_id}", headers=headers
-        )
-        response.encoding = "utf-8"
-
-        if response.status_code == 200:
-            return response.text
-        else:
-            raise RuntimeError("Not found")
-    except Exception as e:
-        warnings.warn(f"An error occurred: {e}")
+    else:
+        logger.info("Falling back to the most recent release on Zenodo.")
+        return entry
 
 
-# if __name__ == "__main__":
-#     jupedsim_bibtex = get_latest_jupedsim_bibtex("v2.0.0")
-#     print(jupedsim_bibtex)
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    print(get_latest_jupedsim_bibtex("v1.4.2"), end="")


### PR DESCRIPTION
Replace the hand rolled Zenodo lookup in docs/source/_scripts with the zenodo-bibtex-exporter tool, which resolves the record by concept id instead of searching for the project name and filtering the results.

The search based lookup read a single page of results, and Zenodo caps that at 25 records for anonymous requests. JuPedSim has more published versions than that, so the older ones were already unreachable: building the documentation for v0.9.0 reported that no citation information was available, for a record that exists. Looking the version up by concept id filters server side and finds it.

The function now always returns a string. Previously it returned None whenever anything went wrong, and conf.py passes the result straight to file.write(), so a brief Zenodo outage failed the documentation build with a TypeError rather than degrading. A development version, which matches no release, took the same path on every build.

Failures now fall back to the most recent release, and an unreachable Zenodo produces a BibTeX comment pointing at the concept DOI, so the generated .bib file stays valid either way.

The signature is unchanged, so conf.py needs no adjustment.

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1652/
<!-- PREVIEW-URL-END -->