### PR TITLE
Update pytest to 9.1 to resolve security alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ build
 setuptools
 
 # test deps
-pytest~=8.3
+pytest~=9.1
 pandas~=2.2
 
 # ci deps


### PR DESCRIPTION
From dependabot: pytest through 9.0.2 on UNIX relies on directories with the /tmp/pytest-of-{user} name pattern, which allows local users to cause a denial of service or possibly gain privileges.

https://github.com/schroedtert/jupedsim/security/dependabot/1

<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1653/
<!-- PREVIEW-URL-END -->