### PR TITLE
Deactivate second search bar on website

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -160,6 +160,7 @@ html_theme_options = {
     },
     "primary_sidebar_end": ["version-switcher"],
     "show_toc_level": 2,
+    "navbar_persistent": [],
 }
 
 html_sidebars = {


### PR DESCRIPTION
Due to the update of sphinx-book-theme, also the underlying pydata-sphinx-theme was updated. This update changes the default behavior of displaying a search bar, when not explicitly disabling it in the persistent navigation bar. As we have our search bar already in the navigation bar, this second search bar now gets removed.

**Current state:**
<img width="822" height="305" alt="image" src="https://github.com/user-attachments/assets/c2865a0b-4db5-4a7f-9456-370f65cb61c6" />

from: https://www.jupedsim.org/pull-requests/1651/

**Fixed state:**

<img width="833" height="258" alt="image" src="https://github.com/user-attachments/assets/38789ffd-3f3d-43a4-842e-920925707923" />



<!-- PREVIEW-URL-START -->
Preview: https://PedestrianDynamics.github.io/jupedsim/pull-requests/1654/
<!-- PREVIEW-URL-END -->